### PR TITLE
Update repo URLs from beijbom to coralnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.1
+
+- Allow configuration of `MAX_IMAGE_PIXELS`, `MAX_POINTS_PER_IMAGE`, and `MIN_TRAINIMAGES`.
+
+- Previously, if `secrets.json` was present but missing a config value, then pyspacer would go on to look for that config value in Django settings. This is no longer the case; pyspacer now only respects at most one of secrets.json or Django settings (secrets take precedence).
+
+- Update repo URL from `beijbom/pyspacer` to `coralnet/pyspacer`.
+
 ## 0.4.0
 
 - PySpacer now supports Python 3.8+ (testing against 3.8 - 3.10). Support for 3.6 and 3.7 has been dropped.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # PySpacer
 
-[![CI Status](https://github.com/beijbom/pyspacer/actions/workflows/python-app.yml/badge.svg)](https://github.com/beijbom/pyspacer/actions/workflows/python-app.yml)
+[![CI Status](https://github.com/coralnet/pyspacer/actions/workflows/python-app.yml/badge.svg)](https://github.com/coralnet/pyspacer/actions/workflows/python-app.yml)
 [![PyPI version](https://badge.fury.io/py/pyspacer.svg)](https://badge.fury.io/py/pyspacer)
 
 This repository provide utilities to extract features from random point 
 locations in images and then training classifiers over those features.
-It is used in the vision backend of `https://github.com/beijbom/coralnet`.
+It is used in the vision backend of `https://github.com/coralnet/coralnet`.
 
 Spacer currently supports python >=3.8.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyspacer"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
   { name="Oscar Beijbom", email="oscar.beijbom@gmail.com" },
 ]
@@ -27,4 +27,4 @@ classifiers = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/beijbom/pyspacer"
+"Homepage" = "https://github.com/coralnet/pyspacer"

--- a/scripts/regression/caffe_extractor.py
+++ b/scripts/regression/caffe_extractor.py
@@ -13,7 +13,7 @@ The run method runs the regression tests. This test
 runs both feature extraction and classification.
 Since the libjpeg version was changed the results will not be identical.
 However, the scores should be close. See discussion in
-(https://github.com/beijbom/pyspacer/pull/10)
+(https://github.com/coralnet/pyspacer/pull/10)
 for more details.
 
 We also run a subset of these tests as part of the standard test suite.
@@ -84,7 +84,7 @@ def get_rowcol(key, storage):
     coralnet/project/vision_backend/management/commands/
     vb_export_spacer_data.py
 
-    https://github.com/beijbom/coralnet/blob/
+    https://github.com/coralnet/coralnet/blob/
     e08afaa0164425fc16ae4ed60841d70f2eff59a6/project/vision_backend/
     management/commands/vb_export_spacer_data.py
     """

--- a/scripts/regression/retrain_source.py
+++ b/scripts/regression/retrain_source.py
@@ -28,7 +28,7 @@ def train(source_id: int,
     It assumes read permission on the "spacer-trainingdata" bucket.
 
     All data is formatted per the management command in
-    https://github.com/beijbom/coralnet/blob/107257fd34cd2c16714b369ec7146ae7222af2c6/project/vision_backend/management/commands/vb_export_spacer_data.py
+    https://github.com/coralnet/coralnet/blob/107257fd34cd2c16714b369ec7146ae7222af2c6/project/vision_backend/management/commands/vb_export_spacer_data.py
     ...
     """
 

--- a/spacer/tests/test_legacy.py
+++ b/spacer/tests/test_legacy.py
@@ -96,7 +96,7 @@ class TestExtractFeatures(unittest.TestCase):
         """
         Note that we use a png image here to avoid the inconsistencies
         with libjpeg versions.
-        See discussion in https://github.com/beijbom/pyspacer/pull/10 for
+        See discussion in https://github.com/coralnet/pyspacer/pull/10 for
         more details on libjpeg.
         """
 


### PR DESCRIPTION
Because we've transferred the coralnet and pyspacer repos from Oscar's account to the newly-created coralnet GitHub organization, per https://github.com/coralnet/coralnet/issues/311.

Also: I'm currently in collaboration with Kim Fisher who works on @data-mermaid, and I'll soon be adding him as a reviewer on PRs for this wave of pyspacer updates (making the pyspacer module work for both CoralNet and MERMAID). Although Kim's not too familiar with pyspacer yet, this is partly just to keep him in the loop as I work.