### PR TITLE
Allow extractors to be loaded from anywhere, not just CoralNet S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,28 @@
 # Changelog
 
+## 0.5.0
+
+- Generalized feature extractor support by allowing use of any `FeatureExtractor` subclass instance, and extractor files loaded from anywhere (not just from CoralNet's S3 bucket, which requires CoralNet auth).
+
+- In `ExtractFeaturesMsg` and `ClassifyImageMsg`, the parameter `feature_extractor_name` (a string) has been replaced with `extractor` (a `FeatureExtractor` instance).
+
+- In `ExtractFeaturesReturnMsg`, `model_was_cached` has been replaced by `extractor_loaded_remotely`, because now filesystem-caching doesn't apply to some extractor files (they may originally be from the filesystem).
+
+- Config variable `LOCAL_MODEL_PATH` is now `EXTRACTORS_CACHE_DIR`. This is now used by any remote-loaded (S3 or URL based) extractor files. If extractor files are loaded from the filesystem, then it's now possible to run PySpacer without defining any config variable values.
+
+- Added `AWS_REGION` config var, which is now required for S3 usage.
+
+- Added `TEST_EXTRACTORS_BUCKET` and `TEST_BUCKET` config vars for unit tests, but these are not really usable by anyone besides core devs at the moment.
+
+- Some raised errors' types have changed to PySpacer's own `ConfigError` or `HashMismatchError`, and there are cases where error-raising semantics/timing have changed slightly.
+
 ## 0.4.1
 
-- Allow configuration of `MAX_IMAGE_PIXELS`, `MAX_POINTS_PER_IMAGE`, and `MIN_TRAINIMAGES`.
+- Allowed configuration of `MAX_IMAGE_PIXELS`, `MAX_POINTS_PER_IMAGE`, and `MIN_TRAINIMAGES`.
 
 - Previously, if `secrets.json` was present but missing a config value, then pyspacer would go on to look for that config value in Django settings. This is no longer the case; pyspacer now only respects at most one of secrets.json or Django settings (secrets take precedence).
 
-- Update repo URL from `beijbom/pyspacer` to `coralnet/pyspacer`.
+- Updated repo URL from `beijbom/pyspacer` to `coralnet/pyspacer`.
 
 ## 0.4.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,14 +102,8 @@ RUN pip3 install scikit-learn==1.1.3
 RUN pip3 install torch==1.13.1
 RUN pip3 install torchvision==0.14.1
 RUN pip3 install boto3==1.26.122
-RUN pip3 install awscli==1.27.122
 
-ENV SPACER_LOCAL_MODEL_PATH=/workspace/models
-WORKDIR /workspace/models
-RUN aws s3 cp --no-sign-request s3://spacer-tools/efficientnet_b0_ver1.pt ${SPACER_LOCAL_MODEL_PATH}/
-RUN aws s3 cp --no-sign-request s3://spacer-tools/vgg16_coralnet_ver1.deploy.prototxt ${SPACER_LOCAL_MODEL_PATH}/
-RUN aws s3 cp --no-sign-request s3://spacer-tools/vgg16_coralnet_ver1.caffemodel ${SPACER_LOCAL_MODEL_PATH}/
-
+ENV SPACER_EXTRACTORS_CACHE_DIR=/workspace/models
 ENV PYTHONPATH="/workspace/spacer:${PYTHONPATH}"
 WORKDIR /workspace
 RUN mkdir spacer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyspacer"
-version = "0.4.1"
+version = "0.5.0"
 authors = [
   { name="Oscar Beijbom", email="oscar.beijbom@gmail.com" },
 ]

--- a/spacer/caffe_utils.py
+++ b/spacer/caffe_utils.py
@@ -9,7 +9,6 @@ from functools import lru_cache
 from typing import List, Any, Tuple
 
 import caffe
-import hashlib
 import numpy as np
 
 from spacer import config
@@ -99,12 +98,6 @@ def load_net(modeldef_path: str,
     :param modelweighs_path: pretrained weights path.
     :return: pretrained model.
     """
-    # To verify that the correct weight is loaded
-    with config.log_entry_and_exit("load net, check SHA"):
-        with open(modelweighs_path, 'rb') as fp:
-            sha256 = hashlib.sha256(fp.read()).hexdigest()
-        assert sha256 == config.MODEL_WEIGHTS_SHA['vgg16']
-
     return caffe.Net(modeldef_path, modelweighs_path, caffe.TEST)
 
 

--- a/spacer/exceptions.py
+++ b/spacer/exceptions.py
@@ -1,3 +1,11 @@
+class ConfigError(Exception):
+    pass
+
+
+class HashMismatchError(Exception):
+    pass
+
+
 class SpacerInputError(Exception):
     """
     This should indicate that the exception was not caused by a spacer bug, but

--- a/spacer/extract_features.py
+++ b/spacer/extract_features.py
@@ -2,29 +2,58 @@
 Defines feature-extractor ABC; implementations; and factory.
 """
 
+from __future__ import annotations
 import abc
+import hashlib
 import random
 import time
-from typing import List
-from typing import Tuple
+from importlib import import_module
+from io import BytesIO
+from pathlib import Path
+from typing import Type
 
 from PIL import Image
 
 from spacer import config
 from spacer.data_classes import PointFeatures, ImageFeatures
+from spacer.exceptions import ConfigError, HashMismatchError
 from spacer.extract_features_utils import crop_patches
-from spacer.messages import ExtractFeaturesReturnMsg
-from spacer.storage import download_model
+from spacer.messages import DataLocation, ExtractFeaturesReturnMsg
+from spacer.storage import storage_factory
 from spacer.torch_utils import extract_feature
 
 
-class FeatureExtractor(abc.ABC):  # pragma: no cover
+class FeatureExtractor(abc.ABC):
+
+    # Subclasses should define their expected data_locations keys here.
+    # See __init__() for an explanation of data_locations.
+    DATA_LOCATION_KEYS: list[str] = []
+
+    def __init__(self,
+                 data_locations: dict[str, DataLocation],
+                 data_hashes: dict[str, str] = None,
+                 **kwargs):
+        # DataLocations of files/blobs used to load the extractor.
+        # Each subclass of FeatureExtractor should expect specific keys
+        # to be present in this dict, one key per file/blob.
+        self.data_locations = data_locations
+        for key in self.DATA_LOCATION_KEYS:
+            if key not in data_locations:
+                raise ValueError(
+                    f"{key} must be present in data_locations for"
+                    f" {self.__class__.__name__}.")
+
+        # SHA256 hashes checking the integrity of the extractor
+        # files/blobs. The dict keys should match those of data_locations.
+        # Don't have to specify a hash for every data location; only the
+        # ones you want to check the integrity of.
+        self.data_hashes = data_hashes or dict()
 
     @abc.abstractmethod
     def __call__(self,
                  im: Image,
-                 rowcols: List[Tuple[int, int]]) \
-            -> Tuple[ImageFeatures, ExtractFeaturesReturnMsg]:
+                 rowcols: list[tuple[int, int]]) \
+            -> tuple[ImageFeatures, ExtractFeaturesReturnMsg]:
         """ Runs the feature extraction """
 
     @property
@@ -32,14 +61,151 @@ class FeatureExtractor(abc.ABC):  # pragma: no cover
     def feature_dim(self) -> int:
         """ Returns the feature dimension of extractor. """
 
+    def serialize(self) -> dict:
+        cls = self.__class__
+        return dict(
+            # Dotted path to the FeatureExtractor subclass,
+            # e.g. 'spacer.extract_features.EfficientNetExtractor'
+            class_path=f'{cls.__module__}.{cls.__name__}',
+            data_locations=dict([
+                (key, loc.serialize())
+                for key, loc in self.data_locations.items()
+            ]),
+            data_hashes=self.data_hashes,
+        )
+
+    @staticmethod
+    def deserialize(data: dict) -> 'FeatureExtractor':
+        working_data = data.copy()
+        class_path = working_data.pop('class_path')
+
+        module_path, class_name = class_path.rsplit('.', 1)
+        module = import_module(module_path)
+        extractor_class: Type['FeatureExtractor'] = getattr(module, class_name)
+
+        working_data['data_locations'] = dict([
+            (key, DataLocation.deserialize(serialized_loc))
+            for key, serialized_loc in working_data['data_locations'].items()
+        ])
+
+        return extractor_class(**working_data)
+
+    def __repr__(self):
+        """
+        Seeing the serialized fields tends to be a more useful repr than
+        `<SomeExtractor object>`.
+        """
+        return str(self.serialize())
+
+    def __eq__(self, other):
+        """This is for some tests comparing equality of messages."""
+        return self.serialize() == other.serialize()
+
+    def _check_data_hash(self, data, key):
+        if key in self.data_hashes:
+            sha256 = hashlib.sha256(data).hexdigest()
+            if sha256 != self.data_hashes[key]:
+                raise HashMismatchError(
+                    f"Hash doesn't match for extractor's"
+                    f" '{key}' file/blob.")
+
+    def data_filepath_for_cache(self, key: str) -> Path:
+        if not config.EXTRACTORS_CACHE_DIR:
+            raise ConfigError(
+                "Must define EXTRACTORS_CACHE_DIR"
+                " to load extractor files/blobs into the filesystem.")
+
+        loc = self.data_locations[key]
+        return Path(config.EXTRACTORS_CACHE_DIR) / loc.filename
+
+    def load_data_into_filesystem(self, key: str) -> tuple[str, bool]:
+        """
+        Ensure the data file/blob of the given key is loaded into the
+        filesystem.
+        Returns:
+        - A filesystem path for that data file/blob.
+        - True if it had to be loaded from remote storage, else False.
+        """
+        loc = self.data_locations[key]
+
+        if loc.storage_type == 'filesystem':
+            return loc.key, False
+
+        filepath_for_cache = self.data_filepath_for_cache(key)
+        file_storage = storage_factory('filesystem')
+        already_in_filesystem = filepath_for_cache.exists()
+
+        if not already_in_filesystem:
+            # Must load into the filesystem.
+            storage = storage_factory(loc.storage_type, loc.bucket_name)
+            data = storage.load(loc.key)
+            file_storage.store(str(filepath_for_cache), data)
+
+        remote_loaded = not already_in_filesystem and loc.is_remote
+        return str(filepath_for_cache), remote_loaded
+
+    def load_data(self, key: str) -> tuple[BytesIO, bool]:
+        """
+        Loads extractor data from the DataLocation
+        `self.data_locations[key]`.
+
+        If the location is remote, caches the data to the filesystem.
+        Cached files are identified by the source location's filename. So
+        be sure that you don't have distinct files with the same filename,
+        or they'll collide with each other.
+
+        Returns:
+        - Byte stream of the data file/blob.
+        - True if it had to be loaded from remote storage, else False.
+
+        Windows beware: behavior is undefined when there are distinct files
+        to cache whose filenames differ only in upper/lowercase.
+        """
+        loc = self.data_locations[key]
+
+        if loc.is_remote:
+
+            data_filepath, remote_loaded = self.load_data_into_filesystem(key)
+            file_storage = storage_factory('filesystem')
+            data = file_storage.load(data_filepath)
+
+            if remote_loaded:
+                # Cache miss.
+                check_hash = True
+            else:
+                # Cache hit.
+                # Skip the hash check in this case, since presumably the
+                # hash was already checked when loading into the cache, and
+                # hash checking for large files may be time consuming.
+                check_hash = False
+
+        else:
+
+            storage = storage_factory(loc.storage_type, loc.bucket_name)
+            data = storage.load(loc.key)
+
+            remote_loaded = False
+            check_hash = True
+
+        if check_hash:
+            self._check_data_hash(data, key)
+        return data, remote_loaded
+
 
 class DummyExtractor(FeatureExtractor):
     """
     This doesn't actually extract any features from the image,
     it just returns dummy information.
-    Note that feature dimension is compatible with the VGG16CaffeExtractor.
     """
-    def __init__(self, feature_dim):
+    def __init__(self,
+                 data_locations: dict[str, DataLocation] = None,
+                 feature_dim: int = 4096,
+                 **kwargs):
+        super().__init__(data_locations or [], **kwargs)
+
+        # If you want these features to be compatible with an actual
+        # classifier, you should make this match the feature_dim that
+        # the classifier was trained on.
         self._feature_dim = feature_dim
 
     def __call__(self, im, rowcols):
@@ -58,18 +224,23 @@ class DummyExtractor(FeatureExtractor):
     def feature_dim(self):
         return self._feature_dim
 
+    def serialize(self) -> dict:
+        data = super().serialize()
+        data['feature_dim'] = self.feature_dim
+        return data
+
 
 class VGG16CaffeExtractor(FeatureExtractor):
 
-    def __init__(self):
-
-        # Cache models and prototxt locally.
-        self.modeldef_path, _ = download_model(
-            'vgg16_coralnet_ver1.deploy.prototxt')
-        self.modelweighs_path, self.model_was_cached = download_model(
-            'vgg16_coralnet_ver1.caffemodel')
+    # definition should be a Caffe prototxt file, typically .prototxt
+    # weights should be a Caffe model file, typically .caffemodel
+    DATA_LOCATION_KEYS = ['definition', 'weights']
 
     def __call__(self, im, rowcols):
+        if not config.HAS_CAFFE:
+            raise ConfigError(
+                f"Need Caffe installed to call"
+                f" {self.__class__.__name__}.")
 
         # We should only reach this line if it is confirmed caffe is available
         from spacer.caffe_utils import classify_from_patchlist
@@ -89,10 +260,15 @@ class VGG16CaffeExtractor(FeatureExtractor):
         del im
 
         # Extract features
+        definition_filepath, _ = \
+            self.load_data_into_filesystem('definition')
+        weights_filepath, remote_loaded = \
+            self.load_data_into_filesystem('weights')
+
         feats = classify_from_patchlist(patch_list,
                                         caffe_params,
-                                        self.modeldef_path,
-                                        self.modelweighs_path,
+                                        definition_filepath,
+                                        weights_filepath,
                                         scorelayer='fc7')
 
         return \
@@ -105,7 +281,7 @@ class VGG16CaffeExtractor(FeatureExtractor):
                 feature_dim=len(feats[0]),
                 npoints=len(feats)
             ), ExtractFeaturesReturnMsg(
-                model_was_cached=self.model_was_cached,
+                extractor_loaded_remotely=remote_loaded,
                 runtime=time.time() - start_time
             )
 
@@ -116,20 +292,19 @@ class VGG16CaffeExtractor(FeatureExtractor):
 
 class EfficientNetExtractor(FeatureExtractor):
 
-    def __init__(self):
-
-        # Cache models locally.
-        self.modelweighs_path, self.model_was_cached = download_model(
-           'efficientnet_b0_ver1.pt')
+    # weights should be a PyTorch tensor file, typically .pt
+    DATA_LOCATION_KEYS = ['weights']
 
     def __call__(self, im, rowcols):
 
         start_time = time.time()
 
+        weights_data, remote_loaded = self.load_data('weights')
+
         # Set torch parameters
         torch_params = {'model_type': 'efficientnet',
                         'model_name': 'efficientnet-b0',
-                        'weights_path': self.modelweighs_path,
+                        'weights_data': weights_data,
                         'num_class': 1275,
                         'crop_size': 224,
                         'batch_size': 10}
@@ -147,30 +322,10 @@ class EfficientNetExtractor(FeatureExtractor):
                             for rc, ft in zip(rowcols, feats)],
             valid_rowcol=True, feature_dim=len(feats[0]), npoints=len(feats)
         ), ExtractFeaturesReturnMsg(
-            model_was_cached=self.model_was_cached,
+            extractor_loaded_remotely=remote_loaded,
             runtime=time.time() - start_time
         )
 
     @property
     def feature_dim(self):
         return 1280
-
-
-def feature_extractor_factory(modelname,
-                              dummy_featuredim=4096) -> FeatureExtractor:
-
-    assert modelname in config.FEATURE_EXTRACTOR_NAMES, \
-        "Model name {} not registered".format(modelname)
-
-    if modelname == 'vgg16_coralnet_ver1':
-        assert config.HAS_CAFFE, \
-            "Need Caffe installed to instantiate {}".format(modelname)
-        with config.log_entry_and_exit("initializing VGG16CaffeExtractor"):
-            extractor = VGG16CaffeExtractor()
-    if modelname == 'efficientnet_b0_ver1':
-        with config.log_entry_and_exit("initializing EfficientNetExtractor"):
-            extractor = EfficientNetExtractor()
-    if modelname == 'dummy':
-        with config.log_entry_and_exit("initializing DummyExtractor"):
-            extractor = DummyExtractor(dummy_featuredim)
-    return extractor

--- a/spacer/storage.py
+++ b/spacer/storage.py
@@ -176,30 +176,6 @@ def storage_factory(storage_type: str, bucketname: Union[str, None] = None):
         return URLStorage()
 
 
-def download_model(keyname: str) -> Tuple[str, bool]:
-    """
-    Utility method to download model to local cache.
-    This is not part of the storage interface since it is a special case,
-    and models need to be downloaded to a specific destination folder to be
-    shared with host filesystem.
-    """
-    assert config.HAS_S3_MODEL_ACCESS, "Need access to model bucket."
-    destination = os.path.join(config.LOCAL_MODEL_PATH, keyname)
-
-    with config.log_entry_and_exit('fetching of model to ' + destination):
-        if not os.path.isfile(destination):
-            with config.log_entry_and_exit('downloading from ' + keyname):
-                s3 = config.get_s3_conn()
-                s3.Bucket(config.MODELS_BUCKET).download_file(keyname,
-                                                              destination)
-                was_cashed = False
-        else:
-            # Already cached, no need to download
-            was_cashed = True
-
-    return destination, was_cashed
-
-
 def store_image(loc: 'DataLocation', img: Image):
     storage = storage_factory(loc.storage_type, loc.bucket_name)
     with BytesIO() as stream:

--- a/spacer/tasks.py
+++ b/spacer/tasks.py
@@ -7,7 +7,6 @@ import traceback
 
 from spacer import config
 from spacer.data_classes import ImageFeatures
-from spacer.extract_features import feature_extractor_factory
 from spacer.messages import \
     ExtractFeaturesMsg, \
     ExtractFeaturesReturnMsg, \
@@ -23,7 +22,6 @@ from spacer.train_classifier import trainer_factory
 
 def extract_features(msg: ExtractFeaturesMsg) -> ExtractFeaturesReturnMsg:
 
-    extractor = feature_extractor_factory(msg.feature_extractor_name)
     img = load_image(msg.image_loc)
 
     assert img.width * img.height <= config.MAX_IMAGE_PIXELS, \
@@ -38,7 +36,7 @@ def extract_features(msg: ExtractFeaturesMsg) -> ExtractFeaturesReturnMsg:
     check_rowcols(msg.rowcols, img)
 
     with config.log_entry_and_exit('actual extraction'):
-        features, return_msg = extractor(img, msg.rowcols)
+        features, return_msg = msg.extractor(img, msg.rowcols)
 
     with config.log_entry_and_exit('storing features'):
         features.store(msg.feature_loc)
@@ -95,8 +93,7 @@ def classify_image(msg: ClassifyImageMsg) -> ClassifyReturnMsg:
     check_rowcols(msg.rowcols, img)
 
     # Extract features
-    extractor = feature_extractor_factory(msg.feature_extractor_name)
-    features, _ = extractor(img, msg.rowcols)
+    features, _ = msg.extractor(img, msg.rowcols)
 
     # Classify
     clf = load_classifier(msg.classifier_loc)

--- a/spacer/tests/common.py
+++ b/spacer/tests/common.py
@@ -1,0 +1,41 @@
+from spacer import config
+
+
+# Extractors used in unit tests.
+#
+# Here we define the extractors in serialized form so that the S3 DataLocations
+# aren't instantiated when importing this module. (Instantiation would get an
+# error if the S3 bucket isn't available.)
+TEST_EXTRACTORS = {
+    'vgg16': dict(
+        class_path='spacer.extract_features.VGG16CaffeExtractor',
+        data_locations=dict(
+            definition=dict(
+                storage_type='s3',
+                key='vgg16_coralnet_ver1.deploy.prototxt',
+                bucket_name=config.TEST_EXTRACTORS_BUCKET,
+            ),
+            weights=dict(
+                storage_type='s3',
+                key='vgg16_coralnet_ver1.caffemodel',
+                bucket_name=config.TEST_EXTRACTORS_BUCKET,
+            ),
+        ),
+        data_hashes=dict(
+            weights='fb83781de0e207ded23bd42d7eb6e75c1e915a6fbef74120f72732984e227cca',
+        ),
+    ),
+    'efficientnet-b0': dict(
+        class_path='spacer.extract_features.EfficientNetExtractor',
+        data_locations=dict(
+            weights=dict(
+                storage_type='s3',
+                key='efficientnet_b0_ver1.pt',
+                bucket_name=config.TEST_EXTRACTORS_BUCKET,
+            ),
+        ),
+        data_hashes=dict(
+            weights='c3dc6d304179c6729c0a0b3d4e60c728bdcf0d82687deeba54af71827467204c',
+        ),
+    ),
+}

--- a/spacer/tests/decorators.py
+++ b/spacer/tests/decorators.py
@@ -1,0 +1,15 @@
+import unittest
+
+from spacer import config
+
+
+require_caffe = unittest.skipUnless(
+    config.HAS_CAFFE, "Requires Caffe to be installed")
+
+require_test_extractors = unittest.skipUnless(
+    config.TEST_EXTRACTORS_BUCKET,
+    "Requires access to the test feature-extractors on S3")
+
+require_test_fixtures = unittest.skipUnless(
+    config.TEST_BUCKET,
+    "Requires access to the test fixtures on S3")

--- a/spacer/tests/test_data_classes.py
+++ b/spacer/tests/test_data_classes.py
@@ -10,6 +10,7 @@ from spacer.data_classes import \
     ImageLabels, \
     ValResults
 from spacer.messages import DataLocation
+from .decorators import require_test_fixtures
 from .utils import temp_filesystem_data_location
 
 
@@ -37,7 +38,7 @@ class TestImageFeatures(unittest.TestCase):
         self.assertEqual(feats.npoints, len(feats.point_features))
         self.assertEqual(feats.feature_dim, len(feats.point_features[0].data))
 
-    @unittest.skipUnless(config.HAS_S3_TEST_ACCESS, 'No access to test bucket')
+    @require_test_fixtures
     def test_legacy_from_s3(self):
         legacy_feat_loc = DataLocation(storage_type='s3',
                                        key='08bfc10v7t.png.featurevector',
@@ -64,7 +65,7 @@ class TestImageFeatures(unittest.TestCase):
 
 class TestImageFeaturesNumpyStore(unittest.TestCase):
 
-    @unittest.skipUnless(config.HAS_S3_TEST_ACCESS, 'No access to test bucket')
+    @require_test_fixtures
     def test_s3(self):
         s3_loc = DataLocation(
             storage_type='s3',
@@ -176,7 +177,7 @@ class TestValResults(unittest.TestCase):
         self.assertRaises(AssertionError, ValResults,
                           gt=gt, est=est, scores=scores, classes=classes)
 
-    @unittest.skipUnless(config.HAS_S3_TEST_ACCESS, 'No access to test bucket')
+    @require_test_fixtures
     def test_legacy(self):
         legacy_loc = DataLocation(storage_type='s3',
                                   key='beta.valresult',

--- a/spacer/tests/test_mailman.py
+++ b/spacer/tests/test_mailman.py
@@ -1,6 +1,7 @@
 import unittest
 
 from spacer import config
+from spacer.extract_features import DummyExtractor
 from spacer.tasks import process_job
 from spacer.messages import \
     JobMsg, \
@@ -32,7 +33,7 @@ class TestProcessJobErrorHandling(unittest.TestCase):
         msg = JobMsg(task_name='extract_features',
                      tasks=[ExtractFeaturesMsg(
                          job_token='test_job',
-                         feature_extractor_name='dummy',
+                         extractor=DummyExtractor(),
                          rowcols=[(1, 1)],
                          image_loc=DataLocation(storage_type='memory',
                                                 key='missing_image'),
@@ -50,8 +51,8 @@ class TestProcessJobErrorHandling(unittest.TestCase):
                      tasks=[ClassifyImageMsg(
                          job_token='my_job',
                          image_loc=DataLocation(storage_type='url',
-                                                key='http://invalid_url.com'),
-                         feature_extractor_name='invalid_name',
+                                                key='http::/invalid_url.com'),
+                         extractor=DummyExtractor(),
                          rowcols=[(1, 1)],
                          classifier_loc=DataLocation(storage_type='memory',
                                                      key='doesnt_matter'))])
@@ -61,24 +62,6 @@ class TestProcessJobErrorHandling(unittest.TestCase):
         self.assertIn("SpacerInputError", return_msg.error_message)
         self.assertEqual(type(return_msg), JobReturnMsg)
 
-    def test_img_classify_feature_extractor_name(self):
-
-        msg = JobMsg(task_name='classify_image',
-                     tasks=[ClassifyImageMsg(
-                         job_token='my_job',
-                         image_loc=DataLocation(storage_type='url',
-                                                key=TEST_URL),
-                         feature_extractor_name='invalid_name',
-                         rowcols=[(1, 1)],
-                         classifier_loc=DataLocation(storage_type='memory',
-                                                     key='doesnt_matter'))])
-        return_msg = process_job(msg)
-        self.assertFalse(return_msg.ok)
-        self.assertIn("AssertionError", return_msg.error_message)
-        self.assertIn("Model name invalid_name not registered",
-                      return_msg.error_message)
-        self.assertEqual(type(return_msg), JobReturnMsg)
-
     def test_img_classify_classifier_key(self):
 
         msg = JobMsg(task_name='classify_image',
@@ -86,7 +69,7 @@ class TestProcessJobErrorHandling(unittest.TestCase):
                          job_token='my_job',
                          image_loc=DataLocation(storage_type='url',
                                                 key=TEST_URL),
-                         feature_extractor_name='dummy',
+                         extractor=DummyExtractor(),
                          rowcols=[(1, 1)],
                          classifier_loc=DataLocation(storage_type='memory',
                                                      key='no_classifier_here')
@@ -138,7 +121,7 @@ class TestProcessJobMultiple(unittest.TestCase):
     def test_multiple_feature_extract(self):
         extract_msg = ExtractFeaturesMsg(
             job_token='test_job',
-            feature_extractor_name='dummy',
+            extractor=DummyExtractor(),
             rowcols=[(1, 1)],
             image_loc=DataLocation(storage_type='url',
                                    key=TEST_URL),
@@ -156,7 +139,7 @@ class TestProcessJobMultiple(unittest.TestCase):
     def test_multiple_feature_extract_one_fail(self):
         good_extract_msg = ExtractFeaturesMsg(
             job_token='test_job',
-            feature_extractor_name='dummy',
+            extractor=DummyExtractor(),
             rowcols=[(1, 1)],
             image_loc=DataLocation(storage_type='url',
                                    key=TEST_URL),
@@ -165,7 +148,7 @@ class TestProcessJobMultiple(unittest.TestCase):
 
         fail_extract_msg = ExtractFeaturesMsg(
             job_token='test_job',
-            feature_extractor_name='dummy',
+            extractor=DummyExtractor(),
             rowcols=[(1, 1)],
             image_loc=DataLocation(storage_type='url',
                                    key='bad_url'),

--- a/spacer/tests/test_messages.py
+++ b/spacer/tests/test_messages.py
@@ -43,12 +43,6 @@ class TestExtractFeaturesMsg(unittest.TestCase):
 
     def test_asserts(self):
         msg = ExtractFeaturesMsg.example()
-        msg.feature_extractor_name = 'invalid_modelname'
-        self.assertRaises(AssertionError,
-                          ExtractFeaturesMsg.deserialize,
-                          msg.serialize())
-
-        msg = ExtractFeaturesMsg.example()
         msg.rowcols = []
         self.assertRaises(AssertionError,
                           ExtractFeaturesMsg.deserialize,
@@ -56,6 +50,12 @@ class TestExtractFeaturesMsg(unittest.TestCase):
 
         msg = ExtractFeaturesMsg.example()
         msg.rowcols = [(120, 101, 121)]
+        self.assertRaises(AssertionError,
+                          ExtractFeaturesMsg.deserialize,
+                          msg.serialize())
+
+        msg = ExtractFeaturesMsg.example()
+        msg.feature_loc = DataLocation('url', 'https://...')
         self.assertRaises(AssertionError,
                           ExtractFeaturesMsg.deserialize,
                           msg.serialize())

--- a/spacer/tests/test_models.py
+++ b/spacer/tests/test_models.py
@@ -3,7 +3,6 @@ import unittest
 
 import torch
 
-from spacer import config
 from spacer import models
 from spacer.models.effcientnet_utils import \
     round_filters, \
@@ -15,7 +14,6 @@ from spacer.models.effcientnet_utils import \
     get_model_params
 
 
-@unittest.skipUnless(config.HAS_S3_MODEL_ACCESS, 'No access to models')
 class TestGetModels(unittest.TestCase):
 
     def test_invalid_model(self):
@@ -25,7 +23,6 @@ class TestGetModels(unittest.TestCase):
                                  num_classes=1000)
 
 
-@unittest.skipUnless(config.HAS_S3_MODEL_ACCESS, 'No access to models')
 class TestEfficientNet(unittest.TestCase):
 
     def test_efficientnet(self):
@@ -49,7 +46,6 @@ class TestEfficientNet(unittest.TestCase):
                              override_params=None)
 
 
-@unittest.skipUnless(config.HAS_S3_MODEL_ACCESS, 'No access to models')
 class TestEfficientNetUtils(unittest.TestCase):
 
     GlobalParams = collections.namedtuple(
@@ -100,7 +96,6 @@ class TestEfficientNetUtils(unittest.TestCase):
         self.assertEqual(cls.__name__, 'Conv2dDynamicSamePadding')
 
 
-@unittest.skipUnless(config.HAS_S3_MODEL_ACCESS, 'No access to models')
 class TestConv2dDynamicSamePadding(unittest.TestCase):
 
     def test_dynamic_padding(self):
@@ -112,7 +107,6 @@ class TestConv2dDynamicSamePadding(unittest.TestCase):
         self.assertEqual(conv.stride, (1, 1))
 
 
-@unittest.skipUnless(config.HAS_S3_MODEL_ACCESS, 'No access to models')
 class TestBlockDecoder(unittest.TestCase):
 
     def test_encode(self):

--- a/spacer/tests/test_train_classifier.py
+++ b/spacer/tests/test_train_classifier.py
@@ -9,7 +9,6 @@ from spacer.train_classifier import trainer_factory
 from spacer.train_utils import make_random_data, train
 
 
-@unittest.skipUnless(config.HAS_S3_TEST_ACCESS, 'No access to test bucket')
 class TestDefaultTrainerDummyData(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Currently you need CoralNet S3 access in order to extract features at all. So, here we try to fix that.

Update:

Generalize feature extractor support by allowing any FeatureExtractor subclass instance, and any file locations instead of just from CoralNet's S3 bucket (which requires auth).

- Test extractors/fixtures are still hidden away in CoralNet infrastructure for now. That's something to address in the future.
- Filesystem-caching now applies to any S3/URL extractor-file locations.
- SHA256-checking for extractor files is still supported, as an optional `data_hashes` in the `FeatureExtractor` constructor.
- Rework relevant config vars. Of note, spacer is now usable without any specified config, if neither S3 or remote-loaded extractors are needed.
- Remove awscli dependency in Dockerfile, because 1) the Dockerfile commands that required awscli no longer apply, and 2) there's currently a Cython 3.x related problem with installing PyYAML, a dependency of awscli (latest PyYAML, 6.0.1, tries to work around it by pinning Cython below 3, but even better to not worry about it at all).

Code/design notes off the top of my head:

- `extract_features.py` has a fair bit of code related to storage now. Maybe some of this should be factored out into `storage.py` later.
- Maybe there should end up being a `File` or `Blob` class which is more general than `DataLocation`. spacer's 'pure' concept of `DataLocation` is to be a location of a `DataClass`. `FeatureExtractor` isn't a `DataClass` as it's not just a vessel for data, it also has a method to extract features. However, `FeatureExtractor` isn't the only instance of the code where the `DataLocation` concept is stretched, with the code reaching directly into the `DataLocation` fields rather than calling its methods. So making a cleaner design would take a few steps. In the interest of time, I put it off for the moment.