### PR TITLE
Update GitHub workflow for PySpacer 0.5.0 & default branch rename

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,9 +2,9 @@ name: Python application
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.8", "3.9", "3.10" ]
-    env:
-      SPACER_LOCAL_MODEL_PATH: $HOME/models
 
     steps:
     - uses: actions/checkout@v2
@@ -26,9 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Make directories
-      run: |
-        mkdir $HOME/models
     - name: Run tests
       run: |
         python -m unittest


### PR DESCRIPTION
So that's why CI wasn't running in the last PR...