### PR TITLE
DummyExtractor: fix data_locations default value in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 (WIP)
+
+- Fixed `DummyExtractor` constructor so that `data_locations` defaults to an empty dict, not an empty list. This fixes serialization of an `ExtractFeaturesMsg` containing `DummyExtractor`.
+
 ## 0.5.0
 
 - Generalized feature extractor support by allowing use of any `FeatureExtractor` subclass instance, and extractor files loaded from anywhere (not just from CoralNet's S3 bucket, which requires CoralNet auth).

--- a/spacer/extract_features.py
+++ b/spacer/extract_features.py
@@ -201,7 +201,7 @@ class DummyExtractor(FeatureExtractor):
                  data_locations: dict[str, DataLocation] = None,
                  feature_dim: int = 4096,
                  **kwargs):
-        super().__init__(data_locations or [], **kwargs)
+        super().__init__(data_locations or dict(), **kwargs)
 
         # If you want these features to be compatible with an actual
         # classifier, you should make this match the feature_dim that


### PR DESCRIPTION
Should be an empty dict, not an empty list.

This fixes serialization of an `ExtractFeaturesMsg` that contains a `DummyExtractor`.