### PR TITLE
Extractor hash check fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1
+
+- In 0.5.0, the hash check when loading a feature extractor was broken in two ways. First, it got an error when trying to check the hash. Second, if the hash check failed for a remote-loaded extractor file, then a second attempt at loading would still allow extraction to proceed. This release fixes both problems.
+
 ## 0.6.0
 
 - Fixed `DummyExtractor` constructor so that `data_locations` defaults to an empty dict, not an empty list. This fixes serialization of an `ExtractFeaturesMsg` containing `DummyExtractor`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyspacer"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
   { name="Oscar Beijbom", email="oscar.beijbom@gmail.com" },
 ]

--- a/spacer/tests/common.py
+++ b/spacer/tests/common.py
@@ -22,7 +22,10 @@ TEST_EXTRACTORS = {
             ),
         ),
         data_hashes=dict(
-            weights='fb83781de0e207ded23bd42d7eb6e75c1e915a6fbef74120f72732984e227cca',
+            definition='7e0d1f6626da0dcfd00cbe62291b2c20'
+                       '626eb7dacf2ba08c5eafa8a6539fad19',
+            weights='fb83781de0e207ded23bd42d7eb6e75c'
+                    '1e915a6fbef74120f72732984e227cca',
         ),
     ),
     'efficientnet-b0': dict(
@@ -35,7 +38,8 @@ TEST_EXTRACTORS = {
             ),
         ),
         data_hashes=dict(
-            weights='c3dc6d304179c6729c0a0b3d4e60c728bdcf0d82687deeba54af71827467204c',
+            weights='c3dc6d304179c6729c0a0b3d4e60c728'
+                    'bdcf0d82687deeba54af71827467204c',
         ),
     ),
 }

--- a/spacer/tests/test_torch_utils.py
+++ b/spacer/tests/test_torch_utils.py
@@ -48,10 +48,10 @@ class TestExtractFeatures(unittest.TestCase):
 
     def test_rgb(self):
 
-        weights_data, _ = self.extractor.load_data('weights')
+        weights_datastream, _ = self.extractor.load_datastream('weights')
         torch_params = {'model_type': 'efficientnet',
                         'model_name': 'efficientnet-b0',
-                        'weights_data': weights_data,
+                        'weights_datastream': weights_datastream,
                         'num_class': 1275,
                         'crop_size': 224,
                         'batch_size': 10}

--- a/spacer/torch_utils.py
+++ b/spacer/torch_utils.py
@@ -28,16 +28,16 @@ def transformation():
 
 
 def load_weights(model: Any,
-                 weights_data: BytesIO) -> Any:
+                 weights_datastream: BytesIO) -> Any:
     """
     Load model weights, original weight saved with DataParallel
     Create new OrderedDict that does not contain `module`.
     :param model: Currently support EfficientNet
-    :param weights_data: model weights, already loaded from storage
+    :param weights_datastream: model weights, already loaded from storage
     :return: well trained model
     """
     # Load weights
-    state_dicts = torch.load(weights_data,
+    state_dicts = torch.load(weights_datastream,
                              map_location=torch.device('cpu'))
 
     with config.log_entry_and_exit('model initialization'):
@@ -64,7 +64,7 @@ def extract_feature(patch_list: List,
     net = models.get_model(model_type=pyparams['model_type'],
                            model_name=pyparams['model_name'],
                            num_classes=pyparams['num_class'])
-    net = load_weights(net, pyparams['weights_data'])
+    net = load_weights(net, pyparams['weights_datastream'])
     net.eval()
 
     transformer = transformation()


### PR DESCRIPTION
In 0.5.0, the hash check when loading a feature extractor was broken in two ways. First, it got an error when trying to check the hash. Second, if the hash check failed for a remote-loaded extractor file, then a second attempt at loading would still allow extraction to proceed.

This PR fixes both problems, and also adds more tests for feature extractor loading (0.5.0 should have done this, but alas, I rushed that version).