### PR TITLE
Some more descriptive error classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0 (WIP)
+
+- Changed the error classes which are raised in various error cases.
+
 ## 0.6.1
 
 - In 0.5.0, the hash check when loading a feature extractor was broken in two ways. First, it got an error when trying to check the hash. Second, if the hash check failed for a remote-loaded extractor file, then a second attempt at loading would still allow extraction to proceed. This release fixes both problems.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.0 (WIP)
 
-- Changed the error classes which are raised in various error cases.
+- Replaced all SpacerInputErrors and some AssertionErrors with more descriptive error classes.
 
 ## 0.6.1
 

--- a/spacer/exceptions.py
+++ b/spacer/exceptions.py
@@ -6,6 +6,10 @@ class HashMismatchError(Exception):
     pass
 
 
+class RowColumnMismatchError(Exception):
+    pass
+
+
 class SpacerInputError(Exception):
     """
     This should indicate that the exception was not caused by a spacer bug, but

--- a/spacer/exceptions.py
+++ b/spacer/exceptions.py
@@ -10,10 +10,23 @@ class RowColumnMismatchError(Exception):
     pass
 
 
-class SpacerInputError(Exception):
+class URLDownloadError(Exception):
     """
-    This should indicate that the exception was not caused by a spacer bug, but
-    by giving inputs that spacer cannot reasonably handle. For example, an
-    unreachable URL given as the image URL to download.
+    This wraps around several different errors that can happen
+    when trying to download from a URLStorage url. This helps to
+    indicate that the exceptions are from a URLStorage url and not
+    some other kind of download/read.
+    The original error's saved in a field in case the handler wants
+    to handle different error causes in different ways.
     """
-    pass
+    def __init__(self, message, original_error):
+        super().__init__(message)
+        self.message = message
+        self.original_error = original_error
+
+    def __str__(self):
+        return (
+            f"{self.message} /"
+            f" Details - {type(self.original_error).__name__}:"
+            f" {self.original_error}"
+        )

--- a/spacer/exceptions.py
+++ b/spacer/exceptions.py
@@ -2,7 +2,15 @@ class ConfigError(Exception):
     pass
 
 
+class DataLimitError(Exception):
+    pass
+
+
 class HashMismatchError(Exception):
+    pass
+
+
+class RowColumnInvalidError(Exception):
     pass
 
 

--- a/spacer/task_utils.py
+++ b/spacer/task_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from PIL import Image
 
 from spacer import config

--- a/spacer/task_utils.py
+++ b/spacer/task_utils.py
@@ -1,28 +1,53 @@
-from typing import List, Tuple
-
 from PIL import Image
 
+from spacer import config
+from spacer.exceptions import DataLimitError, RowColumnInvalidError
 
-def check_rowcols(rowcols: List[Tuple[int, int]],
-                  image: Image):
+
+def check_extract_inputs(image: Image,
+                         rowcols: list[tuple[int, int]],
+                         im_key: str):
 
     im_width, im_height = image.size
 
+    if im_width * im_height > config.MAX_IMAGE_PIXELS:
+        raise DataLimitError(
+            f"Image {im_key} has {im_width} x {im_height}"
+            f" = {im_width * im_height} total pixels, which is larger"
+            f" than the max allowed of {config.MAX_IMAGE_PIXELS}."
+        )
+    if len(rowcols) > config.MAX_POINTS_PER_IMAGE:
+        raise DataLimitError(
+            f"{len(rowcols)} point locations were specified for image"
+            f" {im_key}, and that's larger than the max allowed of"
+            f" {config.MAX_POINTS_PER_IMAGE}."
+        )
+
     for row, col in rowcols:
-        assert(isinstance(row, int)), \
-            "Rows must be integers. Given was: [{}]".format(row)
 
-        assert (isinstance(col, int)), \
-            "Columns must be integers. Given was: [{}]".format(col)
+        if not isinstance(row, int):
+            raise RowColumnInvalidError(
+                f"{im_key}: Row values must be integers."
+                f" Given value was: {row}")
+        if not isinstance(col, int):
+            raise RowColumnInvalidError(
+                f"{im_key}: Column values must be integers."
+                f" Given value was: {col}")
 
-        assert (row >= 0), \
-            "Rows must be non-negative. Given was: [{}]".format(row)
+        if row < 0:
+            raise RowColumnInvalidError(
+                f"{im_key}: Row values must be non-negative."
+                f" Given value was: {row}")
+        if col < 0:
+            raise RowColumnInvalidError(
+                f"{im_key}: Column values must be non-negative."
+                f" Given value was: {col}")
 
-        assert (col >= 0), \
-            "Columns must be non-negative. Given was: [{}]".format(col)
-
-        assert row < im_height, \
-            "Row {} outside image with nrows: {}".format(row, im_height)
-
-        assert col < im_width, \
-            "Column {} outside image with ncols: {}".format(col, im_width)
+        if row >= im_height:
+            raise RowColumnInvalidError(
+                f"{im_key}: Row value {row} falls outside this image's"
+                f" valid range of 0-{im_height - 1}.")
+        if col >= im_width:
+            raise RowColumnInvalidError(
+                f"{im_key}: Column value {col} falls outside this image's"
+                f" valid range of 0-{im_width - 1}.")

--- a/spacer/tasks.py
+++ b/spacer/tasks.py
@@ -16,7 +16,7 @@ from spacer.messages import \
     ClassifyImageMsg, \
     ClassifyReturnMsg, JobMsg, JobReturnMsg
 from spacer.storage import load_image, load_classifier, store_classifier
-from spacer.task_utils import check_rowcols
+from spacer.task_utils import check_extract_inputs
 from spacer.train_classifier import trainer_factory
 
 
@@ -24,16 +24,7 @@ def extract_features(msg: ExtractFeaturesMsg) -> ExtractFeaturesReturnMsg:
 
     img = load_image(msg.image_loc)
 
-    assert img.width * img.height <= config.MAX_IMAGE_PIXELS, \
-        "Image ({}, {}) with {} pixels too large. (max: {})".format(
-            img.width, img.height, img.width * img.height,
-            config.MAX_IMAGE_PIXELS)
-    assert len(msg.rowcols) <= config.MAX_POINTS_PER_IMAGE, \
-        "Too many rowcol locations ({}). Max {} allowed".format(
-            len(msg.rowcols), config.MAX_POINTS_PER_IMAGE
-        )
-
-    check_rowcols(msg.rowcols, img)
+    check_extract_inputs(img, msg.rowcols, msg.image_loc.key)
 
     with config.log_entry_and_exit('actual extraction'):
         features, return_msg = msg.extractor(img, msg.rowcols)
@@ -90,7 +81,7 @@ def classify_image(msg: ClassifyImageMsg) -> ClassifyReturnMsg:
 
     # Download image
     img = load_image(msg.image_loc)
-    check_rowcols(msg.rowcols, img)
+    check_extract_inputs(img, msg.rowcols, msg.image_loc.key)
 
     # Extract features
     features, _ = msg.extractor(img, msg.rowcols)

--- a/spacer/tests/test_mailman.py
+++ b/spacer/tests/test_mailman.py
@@ -47,19 +47,20 @@ class TestProcessJobErrorHandling(unittest.TestCase):
 
     def test_img_classify_bad_url(self):
 
+        bad_url = 'http::/invalid_url.com'
         msg = JobMsg(task_name='classify_image',
                      tasks=[ClassifyImageMsg(
                          job_token='my_job',
                          image_loc=DataLocation(storage_type='url',
-                                                key='http::/invalid_url.com'),
+                                                key=bad_url),
                          extractor=DummyExtractor(),
                          rowcols=[(1, 1)],
                          classifier_loc=DataLocation(storage_type='memory',
                                                      key='doesnt_matter'))])
         return_msg = process_job(msg)
         self.assertFalse(return_msg.ok)
-        self.assertIn("URLError", return_msg.error_message)
-        self.assertIn("SpacerInputError", return_msg.error_message)
+        self.assertIn("URLDownloadError", return_msg.error_message)
+        self.assertIn(bad_url, return_msg.error_message)
         self.assertEqual(type(return_msg), JobReturnMsg)
 
     def test_img_classify_classifier_key(self):

--- a/spacer/tests/test_task_utils.py
+++ b/spacer/tests/test_task_utils.py
@@ -2,51 +2,60 @@ import unittest
 
 from PIL import Image
 
-from spacer.task_utils import check_rowcols
+from spacer.exceptions import RowColumnInvalidError
+from spacer.task_utils import check_extract_inputs
 
 
-class TestRowColCheck(unittest.TestCase):
+class TestRowColChecks(unittest.TestCase):
 
     def test_ints(self):
         img = Image.new('RGB', (100, 100))
         rowcols = [(1.1, 1.2)]
-        self.assertRaises(AssertionError, check_rowcols, rowcols, img)
+        with self.assertRaises(RowColumnInvalidError):
+            check_extract_inputs(img, rowcols, 'img')
 
     def test_ok(self):
         img = Image.new('RGB', (100, 100))
         rowcols = [(0, 0), (99, 99)]
         try:
-            check_rowcols(rowcols, img)
+            check_extract_inputs(img, rowcols, 'img')
         except AssertionError:
-            self.fail("check_rowcols raised error unexpectedly")
+            self.fail("check_extract_inputs raised error unexpectedly")
 
     def test_negative(self):
         img = Image.new('RGB', (100, 100))
         rowcols = [(-1, -1)]
-        self.assertRaises(AssertionError, check_rowcols, rowcols, img)
+        with self.assertRaises(RowColumnInvalidError):
+            check_extract_inputs(img, rowcols, 'img')
 
     def test_too_large(self):
         img = Image.new('RGB', (100, 100))
         rowcols = [(100, 100)]
-        self.assertRaises(AssertionError, check_rowcols, rowcols, img)
+        with self.assertRaises(RowColumnInvalidError):
+            check_extract_inputs(img, rowcols, 'img')
 
     def test_row_too_large(self):
         img = Image.new('RGB', (100, 100))
         rowcols = [(100, 99)]
-        try:
-            check_rowcols(rowcols, img)
-        except AssertionError as err:
-            self.assertIn('row', repr(err))
-            self.assertNotIn('col', repr(err))
+
+        with self.assertRaises(RowColumnInvalidError) as context:
+            check_extract_inputs(img, rowcols, 'img')
+        self.assertEqual(
+            str(context.exception),
+            "img: Row value 100 falls outside this image's"
+            " valid range of 0-99.")
 
     def test_col_too_large(self):
         img = Image.new('RGB', (100, 100))
         rowcols = [(99, 100)]
-        try:
-            check_rowcols(rowcols, img)
-        except AssertionError as err:
-            self.assertIn('col', repr(err))
-            self.assertNotIn('row', repr(err))
+
+        with self.assertRaises(RowColumnInvalidError) as context:
+            check_extract_inputs(img, rowcols, 'img')
+        self.assertEqual(
+            str(context.exception),
+            "img: Column value 100 falls outside this image's"
+            " valid range of 0-99.")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Replaced all SpacerInputErrors and some AssertionErrors with more descriptive error classes: URLDownloadError, RowColumnMismatchError, RowColumnInvalidError, and DataLimitError.

In pyspacer 0.4.0, I had the idea of introducing the SpacerInputError class to indicate that an error was most likely caused by unexpected user inputs rather than by a pyspacer bug. However, now I consider that concept misguided for a pluggable app like pyspacer, because it shouldn't be able to tell who gets the "blame" for a particular error; that depends on the application.

So these new error classes just make an effort to group certain errors usefully, so that the caller can decide how to handle the errors appropriately based on context. Note that URLDownloadError is the most broad error and it actually wraps around the original error that spacer catches (can be a ValueError, urllib.error.URLError, or http.client.IncompleteRead), but the original error is available in the `original_error` field in case the caller wants it.