### PR TITLE
Training: specifying ref set + filtering by class + better batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
   - A dict which maps each of the keys `train`, `ref`, and `val` to a different `ImageLabels` object.
 
+- Removed `MIN_TRAINIMAGES` config var. Minimum number of images for training is now 1 train set, 1 ref set, and 1 val set; or 3 total if leaving the split to pyspacer.
+
 - Added `LOG_DESTINATION` and `LOG_LEVEL` config vars, providing configurable logging for test-suite runs or quick scripts.
 
 - Logging statements throughout pyspacer's codebase now use module-name loggers rather than the root logger, allowing end-applications to keep their logs organized.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ## 0.7.0 (WIP)
 
-- `TrainClassifierMsg` labels arguments have changed. Instead of `train_labels` and `val_labels`, it now takes a single argument `labels`, which can be in either of two forms:
+- `TrainClassifierMsg` labels arguments have changed. Instead of `train_labels` and `val_labels`, it now takes a single argument `labels`, which is a `TrainingTaskLabels` object (basically a set of 3 `ImageLabels` objects: training set, reference set, and validation set).
 
-  - A single `ImageLabels` object which pyspacer will decide how to split into training (train), reference (ref), and validation (val) sets.
-
-  - A dict which maps each of the keys `train`, `ref`, and `val` to a different `ImageLabels` object.
+- The new function `task_utils.preprocess_labels()` can be called in advance of building a TrainClassifierMsg, to 1) split a single ImageLabels instance into reasonably-proportioned train/ref/val sets, 2) filter labels to only a desired set of classes, and 3) run error checks.
 
 - Removed `MIN_TRAINIMAGES` config var. Minimum number of images for training is now 1 train set, 1 ref set, and 1 val set; or 3 total if leaving the split to pyspacer.
 
@@ -14,7 +12,7 @@
 
 - Logging statements throughout pyspacer's codebase now use module-name loggers rather than the root logger, allowing end-applications to keep their logs organized.
 
-- Replaced all SpacerInputErrors and some AssertionErrors with more descriptive error classes.
+- Updated various error cases (mainly SpacerInputErrors, asserts, and ValueErrors) with more descriptive error classes. The `SpacerInputError` class is no longer available.
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.7.0 (WIP)
 
+- `TrainClassifierMsg` labels arguments have changed. Instead of `train_labels` and `val_labels`, it now takes a single argument `labels`, which can be in either of two forms:
+
+  - A single `ImageLabels` object which pyspacer will decide how to split into training (train), reference (ref), and validation (val) sets.
+
+  - A dict which maps each of the keys `train`, `ref`, and `val` to a different `ImageLabels` object.
+
 - Added `LOG_DESTINATION` and `LOG_LEVEL` config vars, providing configurable logging for test-suite runs or quick scripts.
 
 - Logging statements throughout pyspacer's codebase now use module-name loggers rather than the root logger, allowing end-applications to keep their logs organized.

--- a/README.md
+++ b/README.md
@@ -103,24 +103,21 @@ Spacer supports four storage types: `s3`, `filesystem`, `memory` and `url`.
 `config.py` defines configurable variables/settings and various constants.
 
 
-## Feature extractors
-
-The first step when analyzing an image, or preparing an image as training data, is extracting [features](https://en.wikipedia.org/wiki/Feature_(computer_vision)) from the image. Therefore, you need a feature extractor to use spacer, but spacer does not provide one out of the box.
-
-Spacer's `extract_features.py` provides the Python classes `EfficientNetExtractor` for loading EfficientNet extractors in PyTorch format (CoralNet 1.0's default extraction scheme), and `VGG16CaffeExtractor` for loading VGG16 extractors in Caffe format (CoralNet's legacy extraction scheme).
-
-You'll either want to match one of these schemes so you can use the provided classes, or you'll have to write your own extractor class which inherits from the base class `FeatureExtractor`. Between the provided classes, the easier one to use will probably be `EfficientNetExtractor`, because Caffe is old software which is more complicated to install.
-
-If you're loading the extractor files remotely (from S3 or from a URL), the files will be automatically cached to your configured `EXTRACTORS_CACHE_DIR` for faster subsequent loads.
-
-
 ## Core API
 
 The `tasks.py` module has four functions which comprise the main interface of pyspacer:
 
 ### extract_features
 
-Takes an image, a list of pixel locations on that image, and a feature extractor. Produces a single feature vector out of the image-data at those pixel locations. Example:
+The first step when analyzing an image, or preparing an image as training data, is extracting [features](https://en.wikipedia.org/wiki/Feature_(computer_vision)) from the image. For this step, you specify a set of points (pixel locations) in the image which you want to analyze. At each point, spacer will crop a square of pixels centered around that location and extract features based on that square.
+
+You'll also need a feature extractor, but spacer does not provide one out of the box. Spacer's `extract_features.py` provides the Python classes `EfficientNetExtractor` for loading EfficientNet extractors in PyTorch format (CoralNet 1.0's default extraction scheme), and `VGG16CaffeExtractor` for loading VGG16 extractors in Caffe format (CoralNet's legacy extraction scheme).
+
+You'll either want to match one of these schemes so you can use the provided classes, or you'll have to write your own extractor class which inherits from the base class `FeatureExtractor`. Between the provided classes, the easier one to use will probably be `EfficientNetExtractor`, because Caffe is old software which is more complicated to install.
+
+If you're loading the extractor files remotely (from S3 or from a URL), the files will be automatically cached to your configured `EXTRACTORS_CACHE_DIR` for faster subsequent loads.
+
+The output of `extract_features()` is a single feature-vector file, which is a JSON file that is deserializable using the `data_classes.ImageFeatures` class. Example usage:
 
 ```python
 from spacer.extract_features import EfficientNetExtractor
@@ -157,14 +154,69 @@ print(f"Extraction runtime: {return_message.runtime:.1f} s")
 
 ### train_classifier
 
-Takes:
+To train a classifier, you need:
 
-- Feature vectors, each vector corresponding to a set of pixel locations in one image
-- Ground-truth (typically human-confirmed) annotations corresponding to those feature vectors
-- Optionally, previously-created classifiers to re-evaluate with these annotations
+- Feature vectors; each vector corresponds to a set of point locations in one image
+- Ground-truth labels (typically applied/confirmed by human inspection) for each of the points specified in those feature vectors
 - Training parameters
 
-Produces a classifier (model) loadable in scikit-learn, and classifier evaluation results. Example:
+The labels must be split into training, reference, and validation sets:
+
+- The training set (train) is the data that actually goes into the classifier training algorithm during each training epoch. This is generally much larger than the other two sets.
+- The reference set (ref) is used to evaluate and calibrate the classifier between epochs. 
+- The validation set (val) is used to evaluate the final classifier after training is finished.
+
+This three-set split is known by other names elsewhere, such as [training, validation, and test sets](https://en.wikipedia.org/wiki/Training%2C_validation%2C_and_test_data_sets) respectively, or [training, development, and test sets](https://cs230.stanford.edu/blog/split/) respectively.
+
+There are a few ways to create the `labels` structure. Each way involves creating one or more instances of `data_classes.ImageLabels`:
+
+```python
+from spacer.data_classes import ImageLabels
+image_labels = ImageLabels({
+    # Labels for one feature vector's points.
+    '/path/to/image1.featurevector': [
+        # Point location at row 1000, column 2000, labeled as class 1.
+        (1000, 2000, 1), 
+        # Point location at row 3000, column 2000, labeled as class 2.
+        (3000, 2000, 2),
+    ],
+    # Labels for another feature vector's points.
+    '/path/to/image2.featurevector': [
+        (1500, 2500, 3),
+        (2500, 500, 1),
+    ],
+})
+```
+
+The `labels` argument of `TrainClassifierMsg` expects an instance of `data_classes.TrainingTaskLabels`. There are a few ways to create this:
+
+1. Pass a single ImageLabels instance to the `task_utils.preprocess_labels()` function. preprocess_labels() then decides how to split up your labels into train, ref, and val (while doing error checks in the meantime), and creates a TrainingTaskLabels instance from there.
+2. Pass three ImageLabels instances to the TrainingTaskLabels constructor: one instance for each of train, ref, and val.
+3. Do method 1, but also specify the `accepted_classes` argument to preprocess_labels(); this makes the function filter out any labels that aren't in the desired set of classes.
+4. Do method 2, but also pass the TrainingTaskLabels through preprocess_labels(). This allows you to use the error-checking and accepted_classes parts of preprocess_labels(), and the train/ref/val split you defined will remain intact.
+
+```python
+from spacer.data_classes import ImageLabels
+from spacer.messages import TrainingTaskLabels
+from spacer.task_utils import preprocess_labels
+
+# 1
+labels = preprocess_labels(ImageLabels(...))
+# 2
+labels = TrainingTaskLabels(
+    train=ImageLabels(...), ref=ImageLabels(...), val=ImageLabels(...))
+# 3
+labels = preprocess_labels(ImageLabels(...), accepted_classes={...})
+# 4
+labels = preprocess_labels(TrainingTaskLabels(...), accepted_classes={...})
+```
+
+So, pass that and the other required arguments to TrainClassifierMsg, and then pass that message to `train_classifier()`, which produces:
+
+- A classifier as an `sklearn.calibration.CalibratedClassifierCV` instance, stored in a pickle (.pkl) file. spacer's `storage.load_classifier()` function can help with loading classifiers that were created in older scikit-learn versions. 
+- Classifier evaluation results as a JSON file.
+
+Example: 
 
 ```python
 from spacer.data_classes import ImageLabels
@@ -183,6 +235,7 @@ message = TrainClassifierMsg(
     # Classifier types available:
     # 1. 'MLP': multi-layer perceptron; newer classifier type for CoralNet
     # 2. 'LR': logistic regression; older classifier type for CoralNet
+    # Both types are run with scikit-learn.
     clf_type='MLP',
     # Point-locations to ground-truth-labels (annotations) mappings
     # used to train the classifier.
@@ -206,8 +259,8 @@ message = TrainClassifierMsg(
     # be different for each feature vector.
     features_loc=DataLocation('filesystem', ''),
     # List of previously-created models (classifiers) to also evaluate
-    # using this dataset, for informational purposes only.
-    # A classifier is stored as a pickled CalibratedClassifierCV.
+    # using this validation set, for informational purposes only.
+    # This can be handy for comparing classifiers.
     previous_model_locs=[
         DataLocation('filesystem', '/path/to/oldclassifier1.pkl'),
         DataLocation('filesystem', '/path/to/oldclassifier2.pkl'),
@@ -221,7 +274,9 @@ return_message = train_classifier(message)
 print("Classifier stored at: /path/to/classifier1.pkl")
 print("Evaluation results stored at: /path/to/valresult.json")
 print(f"New model's accuracy (0.0 = 0%, 1.0 = 100%): {return_message.acc}")
-print(f"Previous models' accuracies: {return_message.pc_accs}")
+print(
+    f"Previous models' accuracies on the validation set:"
+    f" {return_message.pc_accs}")
 print(
     "New model's accuracy progression (calculated on the reference set)"
     f" after each epoch of training: {return_message.ref_accs}")
@@ -231,12 +286,28 @@ print(f"Training runtime: {return_message.runtime:.1f} s")
 Evaluation results consist of three arrays:
 
 - `gt`: Ground-truth label IDs for each point in the validation set.
-- `est`: Estimated (classifier-predicted) label IDs for each point.
+- `est`: Estimated (classifier-predicted) label IDs for each point in the validation set.
 - `scores`: Classifier's confidence scores (0.0 = 0%, 1.0 = 100%) for each estimated label ID.
 
 The *i*th element of `gt`, *i*th element of `est`, and *i*th element of `scores` correspond to each other. But the elements are otherwise in an undefined order.
 
 Accuracy is defined as the percentage of `gt` labels that match the corresponding `est` labels.
+
+Here's a snippet which lists out the evaluation results:
+
+```python
+import json
+from spacer.data_classes import ValResults
+with open('/path/to/valresult.json') as f:
+    valresult = ValResults.deserialize(json.load(f))
+for ground_truth_i, prediction_i, score in zip(
+    valresult.gt, valresult.est, valresult.scores
+):
+    print(
+        f"Actual = {valresult.classes[ground_truth_i]},"
+        f" Predicted = {valresult.classes[prediction_i]},"
+        f" Confidence = {100*score:.1f}%")
+```
 
 ### classify_features
 
@@ -311,7 +382,7 @@ for row, col, scores in return_message.scores:
 
 ## Unit tests
 
-Run the test suite by running `python -m unittest` from the `spacer` directory.
+If you are using the docker build or local install, you can run the test suite by running `python -m unittest` from the `spacer` directory.
 
 - Expect many tests to be skipped, since most test fixtures aren't set up for public access yet.
 
@@ -319,10 +390,10 @@ Run the test suite by running `python -m unittest` from the `spacer` directory.
 
 - You can get logging output during test runs with the `LOG_DESTINATION` and `LOG_LEVEL` vars in config.py.
 
-If you are using the docker build or local install, 
-you can check code coverage like so:
+You can check code coverage like so:
+
 ```
-    coverage run --source=spacer --omit=spacer/tests/* -m unittest    
-    coverage report -m
-    coverage html
+coverage run --source=spacer --omit=spacer/tests/* -m unittest    
+coverage report -m
+coverage html
 ```

--- a/spacer/config.py
+++ b/spacer/config.py
@@ -255,6 +255,12 @@ MAX_POINTS_PER_IMAGE = get_config_value('MAX_POINTS_PER_IMAGE', default=1000)
 # The train_classifier task requires as least this many images.
 MIN_TRAINIMAGES = get_config_value('MIN_TRAINIMAGES', default=10)
 
+# Size of training batches. This number of features must be able to fit
+# in memory. Raising this allows the reference set to be larger,
+# which can improve calibration results.
+TRAINING_BATCH_LABEL_COUNT = get_config_value(
+    'TRAINING_BATCH_LABEL_COUNT', default=5000)
+
 # Check access to select which tests to run.
 HAS_CAFFE = importlib.util.find_spec("caffe") is not None
 

--- a/spacer/config.py
+++ b/spacer/config.py
@@ -252,9 +252,6 @@ STORAGE_TYPES = [
 MAX_IMAGE_PIXELS = get_config_value('MAX_IMAGE_PIXELS', default=10000*10000)
 MAX_POINTS_PER_IMAGE = get_config_value('MAX_POINTS_PER_IMAGE', default=1000)
 
-# The train_classifier task requires as least this many images.
-MIN_TRAINIMAGES = get_config_value('MIN_TRAINIMAGES', default=10)
-
 # Size of training batches. This number of features must be able to fit
 # in memory. Raising this allows the reference set to be larger,
 # which can improve calibration results.
@@ -294,7 +291,6 @@ CONFIGURABLE_VARS = [
     'LOG_LEVEL',
     'MAX_IMAGE_PIXELS',
     'MAX_POINTS_PER_IMAGE',
-    'MIN_TRAINIMAGES',
 ]
 
 

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -73,6 +73,7 @@ class ImageLabels(DataClass):
                  # (row, col, label).
                  data: dict[str, list[tuple[int, int, int]]]):
         self.data = data
+        self.label_count = sum([len(labels) for labels in data.values()])
 
     @classmethod
     def example(cls):
@@ -94,14 +95,10 @@ class ImageLabels(DataClass):
     def image_keys(self):
         return list(self.data.keys())
 
-    @property
-    def samples_per_image(self):
-        return len(next(iter(self.data.values())))
-
-    def unique_classes(self, key_list: list[str]) -> set[int]:
-        """ Returns the set of all unique classes in the key_list subset. """
+    def unique_classes(self) -> set[int]:
+        """ Returns the set of all unique classes in the data. """
         labels = set()
-        for im_key in key_list:
+        for im_key in self.image_keys:
             labels |= {label for (row, col, label) in self.data[im_key]}
         return labels
 

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -72,7 +72,7 @@ class ImageLabels(DataClass):
                  # Data maps a feature key (or file path) to a List of
                  # (row, col, label).
                  data: dict[str, list[tuple[int, int, int]]]):
-        self.data = data
+        self._data = data
 
         self.label_count = sum([len(labels) for labels in data.values()])
 
@@ -92,19 +92,20 @@ class ImageLabels(DataClass):
         })
 
     def serialize(self) -> dict:
-        """ Only need the `data` field; the other fields can be recomputed. """
-        return self.data
+        """Only need the `_data` field; the other fields can be recomputed."""
+        return self._data
 
     @classmethod
     def deserialize(cls, data: dict) -> 'ImageLabels':
-        """ Custom deserializer required to convert back to tuples. """
-        return ImageLabels(
-            data={key: [tuple(entry) for entry in value] for
-                  key, value in data.items()})
+        """Custom deserializer required to convert back to tuples."""
+        return ImageLabels({
+            key: [tuple(entry) for entry in value] for
+            key, value in data.items()
+        })
 
     @property
     def image_keys(self):
-        return list(self.data.keys())
+        return list(self._data.keys())
 
     def filter_classes(self, accepted_classes) -> 'ImageLabels':
         """
@@ -115,7 +116,7 @@ class ImageLabels(DataClass):
         for image_key in self.image_keys:
             this_image_labels = [
                 (row, column, label)
-                for row, column, label in self.data[image_key]
+                for row, column, label in self._data[image_key]
                 if label in accepted_classes
             ]
             # Only include an image if it has any labels remaining
@@ -125,7 +126,13 @@ class ImageLabels(DataClass):
         return ImageLabels(data)
 
     def __len__(self):
-        return len(self.data)
+        return len(self._data)
+
+    def __getitem__(self, item):
+        return self._data[item]
+
+    def __contains__(self, item):
+        return item in self._data
 
 
 class PointFeatures(DataClass):

--- a/spacer/exceptions.py
+++ b/spacer/exceptions.py
@@ -18,6 +18,10 @@ class RowColumnMismatchError(Exception):
     pass
 
 
+class TrainingLabelsError(Exception):
+    pass
+
+
 class URLDownloadError(Exception):
     """
     This wraps around several different errors that can happen

--- a/spacer/messages.py
+++ b/spacer/messages.py
@@ -200,13 +200,27 @@ class TrainClassifierMsg(DataClass):
         if isinstance(labels, dict):
             # The caller has decided how to split the data into
             # training, reference, and validation sets.
+            for set_name in ['train', 'ref', 'val']:
+                if set_name not in labels:
+                    raise ValueError(
+                        f"TrainClassifierMsg: labels must include"
+                        f" '{set_name}' set.")
             self.labels = labels
         else:
             # Split data into training, reference, and validation sets.
+            #
             # Arbitrarily, validation gets 10%, reference gets
             # min(10%, TRAINING_BATCH_LABEL_COUNT), training gets the rest.
             # This is imprecise because it's split on the image level, not the
             # label level, and images can have different numbers of labels.
+            #
+            # The split is done in a way which guarantees that all 3 sets are
+            # non-empty if there are at least 3 images.
+            if len(labels) < 3:
+                raise ValueError(
+                    f"TrainClassifierMsg: labels has {len(labels)} images,"
+                    f" but need at least 3.")
+
             train_data = dict()
             ref_data = dict()
             val_data = dict()

--- a/spacer/task_utils.py
+++ b/spacer/task_utils.py
@@ -109,7 +109,7 @@ def preprocess_labels(
         ref_done = False
 
         for image_index, image_key in enumerate(labels_in.image_keys):
-            this_image_labels = labels_in.data[image_key]
+            this_image_labels = labels_in[image_key]
 
             if image_index % 10 == 0:
                 # 1st, 11th, 21st, etc. images go in val.

--- a/spacer/task_utils.py
+++ b/spacer/task_utils.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
+from logging import getLogger
 
 from PIL import Image
 
 from spacer import config
-from spacer.exceptions import DataLimitError, RowColumnInvalidError
+from spacer.data_classes import ImageLabels
+from spacer.exceptions import (
+    DataLimitError, RowColumnInvalidError, TrainingLabelsError)
+from spacer.messages import TrainingTaskLabels
+
+logger = getLogger(__name__)
 
 
 def check_extract_inputs(image: Image,
@@ -53,3 +59,108 @@ def check_extract_inputs(image: Image,
             raise RowColumnInvalidError(
                 f"{im_key}: Column value {col} falls outside this image's"
                 f" valid range of 0-{im_width - 1}.")
+
+
+def preprocess_labels(
+        # Training labels (annotations); two acceptable formats:
+        #
+        # 1) An ImageLabels instance, which this function decides how to
+        # split up into training, reference, and validation sets.
+        # 2) A dict which has keys 'train', 'ref', and 'val',
+        # each mapping to a separate ImageLabels instance.
+        labels_in: ImageLabels | TrainingTaskLabels,
+        # If present, the passed labels are filtered so that any classes not
+        # included in this set have their labels discarded.
+        accepted_classes: set[int] | None = None) -> TrainingTaskLabels:
+    """
+    This function can be used to preprocess labels before creating a
+    TrainClassifierMsg. It does:
+    1) Splitting of labels into train/ref/val, if not already done
+    2) Filtering of labels by valid_classes, if that arg is specified
+    3) Error checks
+
+    This is also called by pyspacer after receiving a TrainClassifierMsg
+    to ensure the error checks are done.
+    """
+
+    if isinstance(labels_in, TrainingTaskLabels):
+        # The caller has decided how to split the data into
+        # training, reference, and validation sets.
+        labels = labels_in
+    else:
+        # Split data into training, reference, and validation sets.
+        #
+        # Arbitrarily, validation gets 10%, reference gets
+        # min(10%, TRAINING_BATCH_LABEL_COUNT), training gets the rest.
+        # This is imprecise because it's split on the image level, not the
+        # label level, and images can have different numbers of labels.
+        #
+        # The split is done in a way which guarantees that all 3 sets are
+        # non-empty if there are at least 3 images.
+        if len(labels_in) < 3:
+            raise TrainingLabelsError(
+                f"The training data has {len(labels_in)} image(s),"
+                f" but need at least 3 to populate train/ref/val sets.")
+
+        train_data = dict()
+        ref_data = dict()
+        val_data = dict()
+        ref_label_count = 0
+        ref_done = False
+
+        for image_index, image_key in enumerate(labels_in.image_keys):
+            this_image_labels = labels_in.data[image_key]
+
+            if image_index % 10 == 0:
+                # 1st, 11th, 21st, etc. images go in val.
+                val_data[image_key] = this_image_labels
+            elif not ref_done and image_index % 10 == 1:
+                # 2nd, 12th, 22nd, etc. images go in ref, if ref still
+                # has room within the batch size; else, go in train.
+                if (ref_label_count + len(this_image_labels)
+                        <= config.TRAINING_BATCH_LABEL_COUNT):
+                    ref_data[image_key] = this_image_labels
+                    ref_label_count += len(this_image_labels)
+                else:
+                    # ref would go over the batch size if it added this
+                    # image.
+                    train_data[image_key] = this_image_labels
+                    ref_done = True
+            else:
+                # The rest go in train.
+                train_data[image_key] = this_image_labels
+
+        labels = TrainingTaskLabels(
+            train=ImageLabels(train_data),
+            ref=ImageLabels(ref_data),
+            val=ImageLabels(val_data),
+        )
+
+    # Identify classes common to both train and ref.
+    train_classes = labels.train.classes_set
+    ref_classes = labels.ref.classes_set
+    train_ref_classes = train_classes.intersection(ref_classes)
+
+    # Further filter the classes if this arg was specified.
+    if accepted_classes:
+        classes_filter = \
+            train_ref_classes.intersection(accepted_classes)
+    else:
+        classes_filter = train_ref_classes
+
+    if len(classes_filter) <= 1:
+        raise TrainingLabelsError(
+            f"Need multiple classes to do training."
+            f" After preprocessing training data, there are"
+            f" {len(classes_filter)} class(es) left.")
+
+    for set_name in ['train', 'ref', 'val']:
+        labels[set_name] = \
+            labels[set_name].filter_classes(classes_filter)
+
+        if len(labels[set_name]) == 0:
+            raise TrainingLabelsError(
+                f"After preprocessing training data,"
+                f" '{set_name}' set is empty.")
+
+    return labels

--- a/spacer/tasks.py
+++ b/spacer/tasks.py
@@ -17,7 +17,7 @@ from spacer.messages import \
     ClassifyReturnMsg, JobMsg, JobReturnMsg
 from spacer.storage import load_image, load_classifier, store_classifier
 from spacer.task_utils import check_extract_inputs
-from spacer.train_classifier import trainer_factory
+from spacer.train_classifier import ClassifierTrainer, trainer_factory
 
 logger = getLogger(__name__)
 
@@ -38,13 +38,12 @@ def extract_features(msg: ExtractFeaturesMsg) -> ExtractFeaturesReturnMsg:
 
 
 def train_classifier(msg: TrainClassifierMsg) -> TrainClassifierReturnMsg:
-    trainer = trainer_factory(msg.trainer_name)
+    trainer: ClassifierTrainer = trainer_factory(msg.trainer_name)
 
     # Do the actual training
     with config.log_entry_and_exit('actual training'):
         clf, val_results, return_message = trainer(
-            msg.train_labels,
-            msg.val_labels,
+            msg.labels,
             msg.nbr_epochs,
             [load_classifier(loc) for loc in msg.previous_model_locs],
             msg.features_loc,

--- a/spacer/tests/test_data_classes.py
+++ b/spacer/tests/test_data_classes.py
@@ -123,9 +123,9 @@ class TestFeatureLabels(unittest.TestCase):
         self.assertEqual(msg, ImageLabels.deserialize(
             json.loads(json.dumps(msg.serialize()))))
 
-    def test_samples_per_image(self):
+    def test_label_count(self):
         msg = ImageLabels.example()
-        self.assertEqual(msg.samples_per_image, 2)
+        self.assertEqual(msg.label_count, 4*2)
 
 
 class TestValResults(unittest.TestCase):

--- a/spacer/tests/test_mailman.py
+++ b/spacer/tests/test_mailman.py
@@ -90,14 +90,13 @@ class TestProcessJobErrorHandling(unittest.TestCase):
                              trainer_name='minibatch',
                              nbr_epochs=1,
                              clf_type=clf_type,
-                             train_labels=ImageLabels(data={
-                                 'my_feats': [(1, 1, 1), (2, 2, 2)]
-                             }),
-                             val_labels=ImageLabels(data={
-                                 'my_feats': [(1, 1, 1), (2, 2, 2)]
+                             labels=ImageLabels(data={
+                                 'feats_1': [(1, 1, 1), (2, 2, 2)],
+                                 'feats_2': [(1, 1, 1), (2, 2, 2)],
+                                 'feats_3': [(1, 1, 1), (2, 2, 2)],
                              }),
                              features_loc=DataLocation(storage_type='memory',
-                                                       key='my_feats'),
+                                                       key=''),
                              previous_model_locs=[
                                  DataLocation(storage_type='memory',
                                               key='my_previous_model')

--- a/spacer/tests/test_mailman.py
+++ b/spacer/tests/test_mailman.py
@@ -2,15 +2,16 @@ import unittest
 
 from spacer import config
 from spacer.extract_features import DummyExtractor
+from spacer.messages import (
+    ClassifyImageMsg,
+    DataLocation,
+    ExtractFeaturesMsg,
+    JobMsg,
+    JobReturnMsg,
+    TrainClassifierMsg,
+    TrainingTaskLabels,
+)
 from spacer.tasks import process_job
-from spacer.messages import \
-    JobMsg, \
-    JobReturnMsg, \
-    ExtractFeaturesMsg, \
-    TrainClassifierMsg, \
-    ClassifyImageMsg, \
-    DataLocation, \
-    ImageLabels
 
 TEST_URL = \
     'https://upload.wikimedia.org/wikipedia/commons/7/7b/Red_sea_coral_reef.jpg'
@@ -90,11 +91,7 @@ class TestProcessJobErrorHandling(unittest.TestCase):
                              trainer_name='minibatch',
                              nbr_epochs=1,
                              clf_type=clf_type,
-                             labels=ImageLabels(data={
-                                 'feats_1': [(1, 1, 1), (2, 2, 2)],
-                                 'feats_2': [(1, 1, 1), (2, 2, 2)],
-                                 'feats_3': [(1, 1, 1), (2, 2, 2)],
-                             }),
+                             labels=TrainingTaskLabels.example(),
                              features_loc=DataLocation(storage_type='memory',
                                                        key=''),
                              previous_model_locs=[

--- a/spacer/tests/test_messages.py
+++ b/spacer/tests/test_messages.py
@@ -12,7 +12,6 @@ from spacer.messages import \
     ClassifyReturnMsg, \
     JobMsg, \
     JobReturnMsg
-from spacer.train_utils import make_random_data
 
 
 class TestDataLocation(unittest.TestCase):
@@ -90,98 +89,6 @@ class TestTrainClassifierMsg(unittest.TestCase):
             msg.serialize()))
         self.assertEqual(msg, TrainClassifierMsg.deserialize(
             json.loads(json.dumps(msg.serialize()))))
-
-    def test_train_ref_val_split(self):
-        """
-        Let pyspacer handle the train/ref/val split.
-        """
-        n_data = 20
-        points_per_image = 10
-        feature_dim = 5
-        class_list = [1, 2]
-        features_loc_template = DataLocation(storage_type='memory', key='')
-
-        msg = TrainClassifierMsg(
-            job_token='test',
-            trainer_name='minibatch',
-            nbr_epochs=1,
-            clf_type='MLP',
-            labels=make_random_data(
-                n_data, class_list, points_per_image,
-                feature_dim, features_loc_template,
-            ),
-            features_loc=features_loc_template,
-            previous_model_locs=[],
-            model_loc=DataLocation(storage_type='memory', key='model'),
-            valresult_loc=DataLocation(storage_type='memory', key='val_res'),
-        )
-
-        # 80% 10% 10%
-        self.assertEqual(len(msg.labels['train']), 16)
-        self.assertEqual(len(msg.labels['ref']), 2)
-        self.assertEqual(len(msg.labels['val']), 2)
-
-    def test_train_ref_val_split_large(self):
-        """
-        This assumes the default batch size config value of 5000 labels.
-
-        Ideally, later we'd be able to override config for specific tests,
-        and then set an override for this test class so that it doesn't
-        depend on the non-test config value.
-        """
-        n_data = 60
-        points_per_image = 1000
-        feature_dim = 5
-        class_list = [1, 2]
-        features_loc_template = DataLocation(storage_type='memory', key='')
-
-        msg = TrainClassifierMsg(
-            job_token='test',
-            trainer_name='minibatch',
-            nbr_epochs=1,
-            clf_type='MLP',
-            labels=make_random_data(
-                n_data, class_list, points_per_image,
-                feature_dim, features_loc_template,
-            ),
-            features_loc=features_loc_template,
-            previous_model_locs=[],
-            model_loc=DataLocation(storage_type='memory', key='model'),
-            valresult_loc=DataLocation(storage_type='memory', key='val_res'),
-        )
-
-        # 80%+ (capped to 5000 points) 10%
-        self.assertEqual(len(msg.labels['train']), 49)
-        self.assertEqual(len(msg.labels['ref']), 5)
-        self.assertEqual(len(msg.labels['val']), 6)
-
-    def test_too_few_images(self):
-        n_data = 2
-        points_per_image = 5
-        feature_dim = 5
-        class_list = [1, 2]
-        features_loc_template = DataLocation(storage_type='memory', key='')
-
-        with self.assertRaises(ValueError) as cm:
-            TrainClassifierMsg(
-                job_token='test',
-                trainer_name='minibatch',
-                nbr_epochs=1,
-                clf_type='MLP',
-                labels=make_random_data(
-                    n_data, class_list, points_per_image,
-                    feature_dim, features_loc_template,
-                ),
-                features_loc=features_loc_template,
-                previous_model_locs=[],
-                model_loc=DataLocation(storage_type='memory', key='model'),
-                valresult_loc=DataLocation(
-                    storage_type='memory', key='val_res'),
-            )
-        self.assertEqual(
-            str(cm.exception),
-            "TrainClassifierMsg: labels has 2 images,"
-            " but need at least 3.")
 
 
 class TestTrainClassifierReturnMsg(unittest.TestCase):

--- a/spacer/tests/test_messages.py
+++ b/spacer/tests/test_messages.py
@@ -12,6 +12,7 @@ from spacer.messages import \
     ClassifyReturnMsg, \
     JobMsg, \
     JobReturnMsg
+from spacer.train_utils import make_random_data
 
 
 class TestDataLocation(unittest.TestCase):
@@ -89,6 +90,98 @@ class TestTrainClassifierMsg(unittest.TestCase):
             msg.serialize()))
         self.assertEqual(msg, TrainClassifierMsg.deserialize(
             json.loads(json.dumps(msg.serialize()))))
+
+    def test_train_ref_val_split(self):
+        """
+        Let pyspacer handle the train/ref/val split.
+        """
+        n_data = 20
+        points_per_image = 10
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        msg = TrainClassifierMsg(
+            job_token='test',
+            trainer_name='minibatch',
+            nbr_epochs=1,
+            clf_type='MLP',
+            labels=make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            features_loc=features_loc_template,
+            previous_model_locs=[],
+            model_loc=DataLocation(storage_type='memory', key='model'),
+            valresult_loc=DataLocation(storage_type='memory', key='val_res'),
+        )
+
+        # 80% 10% 10%
+        self.assertEqual(len(msg.labels['train']), 16)
+        self.assertEqual(len(msg.labels['ref']), 2)
+        self.assertEqual(len(msg.labels['val']), 2)
+
+    def test_train_ref_val_split_large(self):
+        """
+        This assumes the default batch size config value of 5000 labels.
+
+        Ideally, later we'd be able to override config for specific tests,
+        and then set an override for this test class so that it doesn't
+        depend on the non-test config value.
+        """
+        n_data = 60
+        points_per_image = 1000
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        msg = TrainClassifierMsg(
+            job_token='test',
+            trainer_name='minibatch',
+            nbr_epochs=1,
+            clf_type='MLP',
+            labels=make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            features_loc=features_loc_template,
+            previous_model_locs=[],
+            model_loc=DataLocation(storage_type='memory', key='model'),
+            valresult_loc=DataLocation(storage_type='memory', key='val_res'),
+        )
+
+        # 80%+ (capped to 5000 points) 10%
+        self.assertEqual(len(msg.labels['train']), 49)
+        self.assertEqual(len(msg.labels['ref']), 5)
+        self.assertEqual(len(msg.labels['val']), 6)
+
+    def test_too_few_images(self):
+        n_data = 2
+        points_per_image = 5
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        with self.assertRaises(ValueError) as cm:
+            TrainClassifierMsg(
+                job_token='test',
+                trainer_name='minibatch',
+                nbr_epochs=1,
+                clf_type='MLP',
+                labels=make_random_data(
+                    n_data, class_list, points_per_image,
+                    feature_dim, features_loc_template,
+                ),
+                features_loc=features_loc_template,
+                previous_model_locs=[],
+                model_loc=DataLocation(storage_type='memory', key='model'),
+                valresult_loc=DataLocation(
+                    storage_type='memory', key='val_res'),
+            )
+        self.assertEqual(
+            str(cm.exception),
+            "TrainClassifierMsg: labels has 2 images,"
+            " but need at least 3.")
 
 
 class TestTrainClassifierReturnMsg(unittest.TestCase):

--- a/spacer/tests/test_storage.py
+++ b/spacer/tests/test_storage.py
@@ -66,13 +66,21 @@ class BaseStorageTest(unittest.TestCase, abc.ABC):
     def do_test_load_store_model(self):
         features_loc_template = DataLocation(storage_type='memory', key='')
         train_labels = make_random_data(
-            im_count=20,
+            im_count=10,
             class_list=[1, 2],
             points_per_image=5,
             feature_dim=5,
             feature_loc=features_loc_template,
         )
-        clf, _ = train(train_labels, features_loc_template, 1, 'LR')
+        ref_labels = make_random_data(
+            im_count=2,
+            class_list=[1, 2],
+            points_per_image=5,
+            feature_dim=5,
+            feature_loc=features_loc_template,
+        )
+        clf, _ = train(
+            train_labels, ref_labels, features_loc_template, 1, 'LR')
         store_classifier(self.tmp_model_loc, clf)
         self.assertTrue(self.storage.exists(self.tmp_model_loc.key))
 

--- a/spacer/tests/test_task_utils.py
+++ b/spacer/tests/test_task_utils.py
@@ -191,14 +191,21 @@ class TestPreprocessLabels(unittest.TestCase):
                     '3': [(300, 300, 3),
                           (100, 100, 1),
                           (200, 200, 2)],
+                    '4': [(100, 300, 3),
+                          (200, 100, 4),
+                          (300, 200, 3)],
                 }),
             ),
+            # Filter to just 1 and 2. Note that, if not for passing this kwarg,
+            # it'd auto filter to 1, 2, 3 because those are all in train+ref.
             accepted_classes={1, 2},
         )
 
         self.assertEqual(labels.train.data['1'], [(100, 100, 1), (200, 200, 2)])
         self.assertEqual(labels.ref.data['2'], [(200, 200, 2), (100, 100, 1)])
         self.assertEqual(labels.val.data['3'], [(100, 100, 1), (200, 200, 2)])
+        self.assertNotIn(
+            '4', labels.val.data, msg="Image 4 should be excluded entirely")
 
 
 if __name__ == '__main__':

--- a/spacer/tests/test_task_utils.py
+++ b/spacer/tests/test_task_utils.py
@@ -2,8 +2,10 @@ import unittest
 
 from PIL import Image
 
-from spacer.exceptions import RowColumnInvalidError
-from spacer.task_utils import check_extract_inputs
+from spacer.exceptions import RowColumnInvalidError, TrainingLabelsError
+from spacer.messages import DataLocation, ImageLabels, TrainingTaskLabels
+from spacer.task_utils import check_extract_inputs, preprocess_labels
+from spacer.train_utils import make_random_data
 
 
 class TestRowColChecks(unittest.TestCase):
@@ -55,6 +57,148 @@ class TestRowColChecks(unittest.TestCase):
             str(context.exception),
             "img: Column value 100 falls outside this image's"
             " valid range of 0-99.")
+
+
+class TestPreprocessLabels(unittest.TestCase):
+
+    def test_train_ref_val_split(self):
+        """
+        Let pyspacer handle the train/ref/val split.
+        """
+        n_data = 20
+        points_per_image = 10
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(make_random_data(
+            n_data, class_list, points_per_image,
+            feature_dim, features_loc_template,
+        ))
+
+        # 80% 10% 10%
+        self.assertEqual(len(labels['train']), 16)
+        self.assertEqual(len(labels['ref']), 2)
+        self.assertEqual(len(labels['val']), 2)
+
+    def test_train_ref_val_split_large(self):
+        """
+        This assumes the default batch size config value of 5000 labels.
+
+        Ideally, later we'd be able to override config for specific tests,
+        and then set an override for this test class so that it doesn't
+        depend on the non-test config value.
+        """
+        n_data = 60
+        points_per_image = 1000
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(make_random_data(
+            n_data, class_list, points_per_image,
+            feature_dim, features_loc_template,
+        ))
+
+        # 80%+ (capped to 5000 points) 10%
+        self.assertEqual(len(labels['train']), 49)
+        self.assertEqual(len(labels['ref']), 5)
+        self.assertEqual(len(labels['val']), 6)
+
+    def test_too_few_images(self):
+        n_data = 2
+        points_per_image = 5
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        with self.assertRaises(TrainingLabelsError) as cm:
+            preprocess_labels(make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ))
+        self.assertEqual(
+            str(cm.exception),
+            "The training data has 2 image(s), but need at least 3"
+            " to populate train/ref/val sets.")
+
+    def test_train_ref_1_common_class(self):
+        points_per_image = 20
+        feature_dim = 5
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        with self.assertRaises(TrainingLabelsError) as cm:
+            preprocess_labels(TrainingTaskLabels(
+                train=make_random_data(
+                    1, [1, 2], points_per_image,
+                    feature_dim, features_loc_template,
+                ),
+                ref=make_random_data(
+                    1, [2, 3], points_per_image,
+                    feature_dim, features_loc_template,
+                ),
+                val=make_random_data(
+                    1, [1, 2, 3], points_per_image,
+                    feature_dim, features_loc_template,
+                ),
+            ))
+        self.assertEqual(
+            str(cm.exception),
+            "Need multiple classes to do training. After preprocessing"
+            " training data, there are 1 class(es) left.")
+
+    def test_trainref_val_0_common_classes(self):
+        points_per_image = 20
+        feature_dim = 5
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        with self.assertRaises(TrainingLabelsError) as cm:
+            preprocess_labels(TrainingTaskLabels(
+                # train+ref: 1, 2
+                train=make_random_data(
+                    1, [1, 2, 3], points_per_image,
+                    feature_dim, features_loc_template,
+                ),
+                ref=make_random_data(
+                    1, [1, 2], points_per_image,
+                    feature_dim, features_loc_template,
+                ),
+                # val: 3
+                val=make_random_data(
+                    1, [3], points_per_image,
+                    feature_dim, features_loc_template,
+                ),
+            ))
+        self.assertEqual(
+            str(cm.exception),
+            "After preprocessing training data, 'val' set is empty.")
+
+    def test_filter_by_accepted_classes(self):
+
+        labels = preprocess_labels(
+            TrainingTaskLabels(
+                train=ImageLabels({
+                    '1': [(100, 100, 1),
+                          (200, 200, 2),
+                          (300, 300, 3)],
+                }),
+                ref=ImageLabels({
+                    '2': [(200, 200, 2),
+                          (300, 300, 3),
+                          (100, 100, 1)],
+                }),
+                val=ImageLabels({
+                    '3': [(300, 300, 3),
+                          (100, 100, 1),
+                          (200, 200, 2)],
+                }),
+            ),
+            accepted_classes={1, 2},
+        )
+
+        self.assertEqual(labels.train.data['1'], [(100, 100, 1), (200, 200, 2)])
+        self.assertEqual(labels.ref.data['2'], [(200, 200, 2), (100, 100, 1)])
+        self.assertEqual(labels.val.data['3'], [(100, 100, 1), (200, 200, 2)])
 
 
 if __name__ == '__main__':

--- a/spacer/tests/test_task_utils.py
+++ b/spacer/tests/test_task_utils.py
@@ -201,11 +201,11 @@ class TestPreprocessLabels(unittest.TestCase):
             accepted_classes={1, 2},
         )
 
-        self.assertEqual(labels.train.data['1'], [(100, 100, 1), (200, 200, 2)])
-        self.assertEqual(labels.ref.data['2'], [(200, 200, 2), (100, 100, 1)])
-        self.assertEqual(labels.val.data['3'], [(100, 100, 1), (200, 200, 2)])
+        self.assertEqual(labels.train['1'], [(100, 100, 1), (200, 200, 2)])
+        self.assertEqual(labels.ref['2'], [(200, 200, 2), (100, 100, 1)])
+        self.assertEqual(labels.val['3'], [(100, 100, 1), (200, 200, 2)])
         self.assertNotIn(
-            '4', labels.val.data, msg="Image 4 should be excluded entirely")
+            '4', labels.val, msg="Image 4 should be excluded entirely")
 
 
 if __name__ == '__main__':

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -8,15 +8,17 @@ from spacer.data_classes import (
 from spacer.exceptions import (
     DataLimitError, RowColumnInvalidError, RowColumnMismatchError)
 from spacer.extract_features import DummyExtractor
-from spacer.messages import \
-    ExtractFeaturesMsg, \
-    ExtractFeaturesReturnMsg, \
-    TrainClassifierMsg, \
-    TrainClassifierReturnMsg, \
-    ClassifyFeaturesMsg, \
-    ClassifyImageMsg, \
-    ClassifyReturnMsg, \
-    DataLocation
+from spacer.messages import (
+    ClassifyFeaturesMsg,
+    ClassifyImageMsg,
+    ClassifyReturnMsg,
+    DataLocation,
+    ExtractFeaturesMsg,
+    ExtractFeaturesReturnMsg,
+    TrainClassifierMsg,
+    TrainClassifierReturnMsg,
+    TrainingTaskLabels,
+)
 from spacer.storage import \
     store_classifier, \
     load_classifier, \
@@ -198,7 +200,7 @@ class TestTrainClassifier(unittest.TestCase):
                 trainer_name='minibatch',
                 nbr_epochs=1,
                 clf_type=clf_type,
-                labels=dict(
+                labels=TrainingTaskLabels(
                     train=train_labels,
                     ref=ref_labels,
                     val=val_labels,
@@ -259,7 +261,7 @@ class TestTrainClassifier(unittest.TestCase):
             trainer_name='minibatch',
             nbr_epochs=1,
             clf_type='LR',
-            labels=dict(
+            labels=TrainingTaskLabels(
                 train=train_labels,
                 ref=ref_labels,
                 val=val_labels,

--- a/spacer/tests/test_train_utils.py
+++ b/spacer/tests/test_train_utils.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import itertools
 import unittest
 
 import numpy as np
@@ -8,20 +7,26 @@ from spacer import config
 from spacer.data_classes import ImageLabels, PointFeatures, ImageFeatures
 from spacer.exceptions import RowColumnMismatchError
 from spacer.messages import DataLocation
-from spacer.train_utils import train, calc_batch_size, chunkify, calc_acc, \
-    load_image_data, load_batch_data, make_random_data, evaluate_classifier
+from spacer.train_utils import (
+    calc_acc,
+    evaluate_classifier,
+    load_batch_data,
+    load_data_as_mini_batches,
+    load_image_data,
+    make_random_data,
+    train,
+)
 
 
 class TestMakeRandom(unittest.TestCase):
 
     def test_nominal(self):
 
-        n_traindata = 200
-        points_per_image = 20
+        n_traindata = 20
+        points_per_image = 200
         feature_dim = 5
         class_list = [1, 2]
 
-        # Create train and val data.
         features_loc_template = DataLocation(storage_type='memory', key='')
 
         traindata = make_random_data(n_traindata,
@@ -30,171 +35,304 @@ class TestMakeRandom(unittest.TestCase):
                                      feature_dim,
                                      features_loc_template)
 
-        self.assertEqual(traindata.samples_per_image, points_per_image)
-        self.assertEqual(len(traindata), n_traindata)
-        self.assertEqual(traindata.samples_per_image * len(traindata),
-                         points_per_image * n_traindata)
+        self.assertEqual(
+            len(traindata), n_traindata,
+            msg="Length (image count) should be as expected")
+        self.assertEqual(
+            traindata.label_count, n_traindata*points_per_image,
+            msg="Label count should be as expected")
 
         one_feature_loc = features_loc_template
-        one_feature_loc.key = list(traindata.data.keys())[0]
+        one_feature_loc.key = traindata.image_keys[0]
         feats = ImageFeatures.load(one_feature_loc)
-        self.assertEqual(feats.feature_dim, feature_dim)
+        self.assertEqual(
+            feats.feature_dim, feature_dim,
+            msg="Should have created features as expected")
 
 
 class TestTrain(unittest.TestCase):
 
     def test_ok(self):
 
-        n_traindata = config.MIN_TRAINIMAGES + 1
+        n_traindata = 5
+        n_refdata = 1
         points_per_image = 20
         feature_dim = 5
         class_list = [1, 2]
         num_epochs = 4
         feature_loc = DataLocation(storage_type='memory', key='')
 
-        labels = make_random_data(n_traindata,
-                                  class_list,
-                                  points_per_image,
-                                  feature_dim,
-                                  feature_loc)
+        train_labels = make_random_data(
+            n_traindata, class_list, points_per_image,
+            feature_dim, feature_loc,
+        )
+        ref_labels = make_random_data(
+            n_refdata, class_list, points_per_image,
+            feature_dim, feature_loc,
+        )
 
         for clf_type in config.CLASSIFIER_TYPES:
-            clf_calibrated, ref_acc = train(labels, feature_loc, num_epochs,
-                                            clf_type)
+            clf_calibrated, ref_acc = train(
+                train_labels, ref_labels, feature_loc,
+                num_epochs, clf_type,
+            )
 
-            self.assertEqual(len(ref_acc), num_epochs)
+            self.assertEqual(
+                len(ref_acc), num_epochs,
+                msg="Sanity check: expecting one ref_acc element per epoch")
 
     def test_mlp_hybrid_mode(self):
 
-        for (ntd, ppi, hls, lr) in [(11, 20, (100,), 1e-3),
-                                    (1000, 100, (200, 100), 1e-4)]:
-            n_traindata = ntd
-            points_per_image = ppi
+        param_sets = [
+            (11, 20, (100,), 1e-3),
+            (100, 1000, (200, 100), 1e-4),
+        ]
+
+        for (n_traindata, points_per_image, hls, lr) in param_sets:
             feature_dim = 5
             class_list = [1, 2]
             num_epochs = 4
             feature_loc = DataLocation(storage_type='memory', key='')
 
-            labels = make_random_data(n_traindata,
-                                      class_list,
-                                      points_per_image,
-                                      feature_dim,
-                                      feature_loc)
+            train_labels = make_random_data(
+                n_traindata, class_list, points_per_image,
+                feature_dim, feature_loc,
+            )
+            ref_labels = make_random_data(
+                1, class_list, points_per_image,
+                feature_dim, feature_loc,
+            )
 
-            clf_calibrated, ref_acc = train(labels, feature_loc, num_epochs,
-                                            'MLP')
+            clf_calibrated, ref_acc = train(
+                train_labels, ref_labels, feature_loc, num_epochs, 'MLP')
             clf_param = clf_calibrated.get_params()['base_estimator']
-            self.assertEqual(clf_param.hidden_layer_sizes, hls)
-            self.assertEqual(clf_param.learning_rate_init, lr)
-
-    def test_too_few_images(self):
-        n_traindata = config.MIN_TRAINIMAGES - 1
-        points_per_image = 20
-        feature_dim = 5
-        class_list = [1, 2]
-        num_epochs = 4
-        feature_loc = DataLocation(storage_type='memory', key='')
-
-        labels = make_random_data(n_traindata,
-                                  class_list,
-                                  points_per_image,
-                                  feature_dim,
-                                  feature_loc)
-
-        for clf_type in config.CLASSIFIER_TYPES:
-            self.assertRaises(ValueError, train, labels, feature_loc,
-                              num_epochs, clf_type)
+            self.assertEqual(
+                clf_param.hidden_layer_sizes, hls,
+                msg="Hidden layer sizes should correspond to label count")
+            self.assertEqual(
+                clf_param.learning_rate_init, lr,
+                msg="Learning rate init value should correspond to label"
+                    " count")
 
     def test_too_few_classes(self):
         """ Can't train with only 1 class! """
-        n_traindata = config.MIN_TRAINIMAGES + 1
         points_per_image = 20
         feature_dim = 5
         class_list = [1]
         num_epochs = 4
         feature_loc = DataLocation(storage_type='memory', key='')
 
-        labels = make_random_data(n_traindata,
-                                  class_list,
-                                  points_per_image,
-                                  feature_dim,
-                                  feature_loc)
+        train_labels = make_random_data(
+            1, class_list, points_per_image,
+            feature_dim, feature_loc,
+        )
+        ref_labels = make_random_data(
+            1, class_list, points_per_image,
+            feature_dim, feature_loc,
+        )
 
         for clf_type in config.CLASSIFIER_TYPES:
-            self.assertRaises(ValueError, train, labels, feature_loc,
-                              num_epochs, clf_type)
+            with self.assertRaises(ValueError):
+                train(
+                    train_labels, ref_labels, feature_loc,
+                    num_epochs, clf_type,
+                )
 
 
 class TestEvaluateClassifier(unittest.TestCase):
 
     def test_simple(self):
+        class_list = [1, 2]
+        points_per_image = 4
+        feature_dim = 5
         feature_loc = DataLocation(storage_type='memory', key='')
-        train_data = make_random_data(10, [1, 2], 4, 5, feature_loc)
-        for clf_type in config.CLASSIFIER_TYPES:
-            clf, _ = train(train_data, feature_loc, 1, clf_type)
+        train_data = make_random_data(
+            9, class_list, points_per_image, feature_dim, feature_loc)
+        ref_data = make_random_data(
+            1, class_list, points_per_image, feature_dim, feature_loc)
+        val_data = make_random_data(
+            3, class_list, points_per_image, feature_dim, feature_loc)
 
-            val_data = make_random_data(3, [1, 2], 4, 5, feature_loc)
-            gts, ests, scores = evaluate_classifier(clf, val_data, [1, 2],
-                                                    feature_loc)
-            self.assertTrue(1 in gts)
-            self.assertTrue(2 in gts)
+        for clf_type in config.CLASSIFIER_TYPES:
+            clf, _ = train(train_data, ref_data, feature_loc, 1, clf_type)
+
+            gts, ests, scores = evaluate_classifier(
+                clf, val_data, class_list, feature_loc)
+            # Sanity checks
+            self.assertTrue(all([gt in class_list for gt in gts]))
+            self.assertTrue(all([est in class_list for est in ests]))
+            self.assertTrue(all([0 < s < 1 for s in scores]))
 
     def test_no_gt(self):
-
+        class_list_train_ref = [1, 2]
+        class_list_val = [3]
+        points_per_image = 4
+        feature_dim = 5
         feature_loc = DataLocation(storage_type='memory', key='')
-        train_data = make_random_data(10, [1, 2], 4, 5, feature_loc)
+        train_data = make_random_data(
+            9, class_list_train_ref, points_per_image,
+            feature_dim, feature_loc)
+        ref_data = make_random_data(
+            1, class_list_train_ref, points_per_image,
+            feature_dim, feature_loc)
+        val_data = make_random_data(
+            3, class_list_val, points_per_image,
+            feature_dim, feature_loc)
+
         for clf_type in config.CLASSIFIER_TYPES:
-            clf, _ = train(train_data, feature_loc, 1, clf_type)
+            clf, _ = train(train_data, ref_data, feature_loc, 1, clf_type)
 
             # Note here that class_list for the val_data doesn't include
             # any samples from classes [1, 2] so the gt will be empty,
             # which will raise an exception.
-            val_data = make_random_data(3, [3], 4, 5, feature_loc)
-            self.assertRaises(ValueError, evaluate_classifier,
-                              clf, val_data, [1, 2], feature_loc)
+            with self.assertRaises(ValueError) as cm:
+                evaluate_classifier(
+                    clf, val_data, class_list_train_ref, feature_loc)
+            self.assertEqual(
+                str(cm.exception),
+                "Can't run validation. Validation set has no classes in"
+                " common with the train+ref set.")
 
 
-class TestCalcBatchSize(unittest.TestCase):
+class TestLoadDataAsMiniBatches(unittest.TestCase):
+    """
+    This assumes the default batch size config value of 5000 labels.
 
-    def setUp(self):
+    Ideally, later we'd be able to override config for specific tests,
+    and then set an override for this test class so that it doesn't
+    depend on the non-test config value.
+    """
+
+    @classmethod
+    def setUpClass(cls):
         config.filter_warnings()
 
-    def test1(self):
+        cls.classes = [1, 2]
+        cls.feature_dim = 5
+        cls.feature_loc = DataLocation(storage_type='memory', key='')
 
-        images_per_batch, batches_per_epoch = calc_batch_size(1000, 10)
-        self.assertEqual(images_per_batch, 10)
-        self.assertEqual(batches_per_epoch, 1)
+    def test_one_non_full_batch(self):
+        im_count = 20
+        points_per_image = 10
+        random_state = 1
+        batches = [batch for batch in load_data_as_mini_batches(
+            make_random_data(
+                im_count, self.classes, points_per_image,
+                self.feature_dim, self.feature_loc),
+            self.feature_loc,
+            self.classes,
+            random_state,
+        )]
 
-    def test2(self):
-        images_per_batch, batches_per_epoch = calc_batch_size(3, 5)
-        self.assertEqual(images_per_batch, 3)
-        self.assertEqual(batches_per_epoch, 2)
+        self.assertEqual(len(batches), 1, msg="Should have 1 batch")
+        self.assertEqual(
+            len(batches[0][0]), 200, msg="Should have 200 point features")
+        self.assertEqual(
+            len(batches[0][1]), 200, msg="Should have 200 labels")
 
-    def test3(self):
-        images_per_batch, batches_per_epoch = calc_batch_size(1, 5)
-        self.assertEqual(images_per_batch, 1)
-        self.assertEqual(batches_per_epoch, 5)
+    def test_one_full_batch(self):
+        im_count = 10
+        points_per_image = 500
+        random_state = 1
+        batches = [batch for batch in load_data_as_mini_batches(
+            make_random_data(
+                im_count, self.classes, points_per_image,
+                self.feature_dim, self.feature_loc),
+            self.feature_loc,
+            self.classes,
+            random_state,
+        )]
 
+        self.assertEqual(len(batches), 1, msg="Should have 1 batch")
+        self.assertEqual(
+            len(batches[0][0]), 5000, msg="Should have 5000 point features")
+        self.assertEqual(
+            len(batches[0][1]), 5000, msg="Should have 5000 labels")
 
-class TestChunkify(unittest.TestCase):
+    def test_multiple_batches(self):
+        im_count = 21
+        points_per_image = 500
+        random_state = 1
+        batches = [batch for batch in load_data_as_mini_batches(
+            make_random_data(
+                im_count, self.classes, points_per_image,
+                self.feature_dim, self.feature_loc),
+            self.feature_loc,
+            self.classes,
+            random_state,
+        )]
 
-    def test1(self):
-        out = chunkify(list(range(10)), 3)
-        self.assertEqual(len(out), 3)
-        self.assertEqual(len(out[0]), 4)
-        self.assertEqual(len(list(itertools.chain.from_iterable(out))), 10)
+        self.assertEqual(len(batches), 3, msg="Should have 3 batches")
+        self.assertEqual(
+            len(batches[0][0]), 5000,
+            msg="Batch 1 should have 5000 point features")
+        self.assertEqual(
+            len(batches[0][1]), 5000, msg="Batch 1 should have 5000 labels")
+        self.assertEqual(
+            len(batches[1][0]), 5000,
+            msg="Batch 2 should have 5000 point features")
+        self.assertEqual(
+            len(batches[1][1]), 5000, msg="Batch 2 should have 5000 labels")
+        self.assertEqual(
+            len(batches[2][0]), 500,
+            msg="Batch 3 should have 500 point features")
+        self.assertEqual(
+            len(batches[2][1]), 500, msg="Batch 3 should have 500 labels")
 
-    def test2(self):
-        out = chunkify(list(range(9)), 3)
-        self.assertEqual(len(out), 3)
-        self.assertEqual(len(out[0]), 3)
-        self.assertEqual(len(list(itertools.chain.from_iterable(out))), 9)
+    def test_one_image_split_between_batches(self):
+        im_count = 1
+        points_per_image = 5001
+        random_state = 1
+        batches = [batch for batch in load_data_as_mini_batches(
+            make_random_data(
+                im_count, self.classes, points_per_image,
+                self.feature_dim, self.feature_loc),
+            self.feature_loc,
+            self.classes,
+            random_state,
+        )]
 
-    def test3(self):
-        out = chunkify(list(range(10)), 10)
-        self.assertEqual(len(out), 10)
-        self.assertEqual(len(out[0]), 1)
-        self.assertEqual(len(list(itertools.chain.from_iterable(out))), 10)
+        self.assertEqual(len(batches), 2, msg="Should have 2 batches")
+        self.assertEqual(
+            len(batches[0][0]), 5000,
+            msg="Batch 1 should have 5000 point features")
+        self.assertEqual(
+            len(batches[0][1]), 5000, msg="Batch 1 should have 5000 labels")
+        self.assertEqual(
+            len(batches[1][0]), 1, msg="Batch 2 should have 1 point feature")
+        self.assertEqual(
+            len(batches[1][1]), 1, msg="Batch 2 should have 1 label")
+
+    def test_repeatable_with_same_random_state(self):
+        im_count = 20
+        points_per_image = 1
+        random_state = 13
+        data = make_random_data(
+            im_count, self.classes, points_per_image,
+            self.feature_dim, self.feature_loc)
+
+        batches_1 = [batch for batch in load_data_as_mini_batches(
+            data,
+            self.feature_loc,
+            self.classes,
+            random_state,
+        )]
+        batches_2 = [batch for batch in load_data_as_mini_batches(
+            data,
+            self.feature_loc,
+            self.classes,
+            random_state,
+        )]
+
+        # Should be pretty unlikely that two random-shuffled
+        # 20-feature lists get the same ordering, unless they were
+        # seeded the same.
+        batches_1_features = [feature for feature in batches_1[0][0]]
+        batches_2_features = [feature for feature in batches_2[0][0]]
+        for i in range(im_count):
+            self.assertTrue(
+                np.array_equal(batches_1_features[i], batches_2_features[i]),
+                msg=f"Element {i} in both batch sets should be the same")
 
 
 class TestAcc(unittest.TestCase):
@@ -209,20 +347,19 @@ class TestAcc(unittest.TestCase):
 
 class TestLoadImageData(unittest.TestCase):
 
-    def setUp(self):
-
+    @classmethod
+    def setUpClass(cls):
         config.filter_warnings()
-        self.feat_key = 'tmp_features'
-        self.feature_loc = DataLocation(storage_type='memory',
-                                        key=self.feat_key)
+        cls.feat_key = 'tmp_features'
+        cls.feature_loc = DataLocation(storage_type='memory',
+                                       key=cls.feat_key)
 
     def fixtures(self, in_order=True, valid_rowcol=True) \
-            -> tuple[ImageLabels, ImageFeatures]:
+            -> tuple[list[tuple[int, int, int]], ImageFeatures]:
 
-        labels = ImageLabels(
-            data={self.feat_key: [(100, 100, 1),
-                                  (200, 200, 2),
-                                  (300, 300, 1)]})
+        labels = [(100, 100, 1),
+                  (200, 200, 2),
+                  (300, 300, 1)]
 
         fv1 = [1.1, 1.2, 1.3]
         fv2 = [2.1, 2.2, 2.3]
@@ -255,59 +392,69 @@ class TestLoadImageData(unittest.TestCase):
 
         labels, features = self.fixtures(in_order=True)
 
-        x, y = load_image_data(labels, self.feat_key, [1, 2], self.feature_loc)
+        x, y = zip(*load_image_data(labels, self.feature_loc, [1, 2]))
 
-        self.assertEqual(y, [1, 2, 1])
+        self.assertEqual(list(y), [1, 2, 1])
         self.assertTrue(np.array_equal(x[0], features.point_features[0].data))
 
-    def test_reverse(self):
-        """ here the order of features and labels are reversed.
-        But it all still works thanks to row, col matching. """
-
+    def test_scrambled(self):
+        """
+        Here the feature ordering is scrambled.
+        But the load result is still the same thanks to row, col matching.
+        """
         labels, features = self.fixtures(in_order=False)
 
-        x, y = load_image_data(labels, self.feat_key, [1, 2], self.feature_loc)
+        x, y = zip(*load_image_data(labels, self.feature_loc, [1, 2]))
 
-        self.assertEqual(y, [1, 2, 1])
-        # Since the order is reversed, the first feature should be the second
-        # vector of point_features list.
+        self.assertEqual(list(y), [1, 2, 1])
+        # Same elements, different order relative to features.
         self.assertTrue(np.array_equal(x[0], features.point_features[1].data))
+        self.assertTrue(np.array_equal(x[1], features.point_features[0].data))
+        self.assertTrue(np.array_equal(x[2], features.point_features[2].data))
 
-    def test_legacy_reverse(self):
+    def test_legacy_scrambled(self):
         """
         Here we pretend the features are legacy such that row, col
         information is not available.
         """
         labels, features = self.fixtures(in_order=False, valid_rowcol=False)
 
-        x, y = load_image_data(labels, self.feat_key, [1, 2], self.feature_loc)
+        x, y = zip(*load_image_data(labels, self.feature_loc, [1, 2]))
 
-        self.assertEqual(y, [1, 2, 1])
-        # Since the order is reversed, the first feature should be the second
-        # vector of point_features list. But it is not.
-        self.assertFalse(np.array_equal(x[0], features.point_features[1].data))
+        self.assertEqual(list(y), [1, 2, 1])
+        # There should have been no attempt to correct the order
+        # relative to features.
+        self.assertTrue(np.array_equal(x[0], features.point_features[0].data))
+        self.assertTrue(np.array_equal(x[1], features.point_features[1].data))
+        self.assertTrue(np.array_equal(x[2], features.point_features[2].data))
 
     def test_smaller_labelset(self):
-        """ Here we use a smaller labelset and assert
-        that the right feature vector is kept """
+        """
+        Here we use a smaller labelset and assert
+        that the right features are kept
+        """
 
         labels, features = self.fixtures(in_order=True, valid_rowcol=True)
 
-        x, y = load_image_data(labels, self.feat_key, [1], self.feature_loc)
+        x, y = zip(*load_image_data(labels, self.feature_loc, [1]))
 
-        self.assertEqual(y, [1, 1])
+        self.assertEqual(list(y), [1, 1])
+        # Just the 1st and 3rd point features
         self.assertTrue(np.array_equal(x[0], features.point_features[0].data))
         self.assertTrue(np.array_equal(x[1], features.point_features[2].data))
 
     def test_other_small_labelset(self):
-        """ Here we use a smaller labelset and assert
-        that the right feature vector is kept """
+        """
+        Here we use a smaller labelset and assert
+        that the right features are kept
+        """
 
         labels, features = self.fixtures(in_order=True, valid_rowcol=True)
 
-        x, y = load_image_data(labels, self.feat_key, [2], self.feature_loc)
+        x, y = zip(*load_image_data(labels, self.feature_loc, [2]))
 
-        self.assertEqual(y, [2])
+        self.assertEqual(list(y), [2])
+        # Just the 2nd point feature
         self.assertTrue(np.array_equal(x[0], features.point_features[1].data))
 
     def test_legacy_smaller_labelset(self):
@@ -317,11 +464,10 @@ class TestLoadImageData(unittest.TestCase):
         """
         labels, features = self.fixtures(in_order=True, valid_rowcol=False)
 
-        x, y = load_image_data(labels, self.feat_key, [1], self.feature_loc)
+        x, y = zip(*load_image_data(labels, self.feature_loc, [1]))
 
-        self.assertEqual(y, [1, 1])
-        # Since the order is reversed, the first feature should be the second
-        # vector of point_features list. But it is not.
+        self.assertEqual(list(y), [1, 1])
+        # Just the 1st and 3rd point features
         self.assertTrue(np.array_equal(x[0], features.point_features[0].data))
         self.assertTrue(np.array_equal(x[1], features.point_features[2].data))
 
@@ -331,10 +477,10 @@ class TestLoadImageData(unittest.TestCase):
         """
         labels, features = self.fixtures(in_order=True, valid_rowcol=True)
 
-        labels.data[self.feat_key][2] = (300, 299, 1)
+        labels[2] = (300, 299, 1)
 
         with self.assertRaises(RowColumnMismatchError) as cm:
-            load_image_data(labels, self.feat_key, [1, 2], self.feature_loc)
+            _, _ = load_image_data(labels, self.feature_loc, [1, 2])
         self.assertEqual(
             str(cm.exception),
             f"{self.feat_key}: The labels' row-column positions don't match"
@@ -347,10 +493,10 @@ class TestLoadImageData(unittest.TestCase):
         """
         labels, features = self.fixtures(in_order=True, valid_rowcol=False)
 
-        labels.data[self.feat_key].append((400, 400, 2))
+        labels.append((400, 400, 2))
 
         with self.assertRaises(RowColumnMismatchError) as cm:
-            load_image_data(labels, self.feat_key, [1, 2], self.feature_loc)
+            _, _ = load_image_data(labels, self.feature_loc, [1, 2])
         self.assertEqual(
             str(cm.exception),
             f"{self.feat_key}: The number of labels (4) doesn't match"
@@ -359,16 +505,16 @@ class TestLoadImageData(unittest.TestCase):
 
 class TestLoadBatchData(unittest.TestCase):
 
-    def setUp(self):
-        
+    @classmethod
+    def setUpClass(cls):
         config.filter_warnings()
-        self.feat_key1 = 'tmp_features1'
-        self.feat_key2 = 'tmp_features2'
-        self.feat1_loc = DataLocation(storage_type='memory',
-                                      key='tmp_features1')
-        self.feat2_loc = DataLocation(storage_type='memory',
-                                      key='tmp_features2')
-        self.feat_loc_template = DataLocation(storage_type='memory', key='')
+        cls.feat_key1 = 'tmp_features1'
+        cls.feat_key2 = 'tmp_features2'
+        cls.feat1_loc = DataLocation(storage_type='memory',
+                                     key='tmp_features1')
+        cls.feat2_loc = DataLocation(storage_type='memory',
+                                     key='tmp_features2')
+        cls.feat_loc_template = DataLocation(storage_type='memory', key='')
 
     def fixtures(self, valid_rowcol=True) \
             -> tuple[ImageLabels, ImageFeatures, ImageFeatures]:
@@ -410,29 +556,32 @@ class TestLoadBatchData(unittest.TestCase):
     def test_simple(self):
 
         labels, features1, features2 = self.fixtures(valid_rowcol=True)
-        x, y = load_batch_data(labels, [self.feat_key1, self.feat_key2],
-                               [1, 2], self.feat_loc_template)
+        x, y = load_batch_data(labels, self.feat_loc_template, [1, 2])
 
-        self.assertTrue(np.array_equal(x[0], features1.point_features[0].data))
-        self.assertTrue(np.array_equal(x[3], features2.point_features[0].data))
+        for a, b in [
+            (x[0], features1.point_features[0].data),
+            (x[1], features1.point_features[1].data),
+            (x[2], features1.point_features[2].data),
+            (x[3], features2.point_features[0].data),
+            (x[4], features2.point_features[1].data),
+            (x[5], features2.point_features[2].data),
+        ]:
+            self.assertTrue(np.array_equal(a, b))
 
-    def test_reverse_imkey_order(self):
-        labels, features1, features2 = self.fixtures(valid_rowcol=True)
-        x, y = load_batch_data(labels, [self.feat_key2, self.feat_key1],
-                               [1, 2], self.feat_loc_template)
-
-        self.assertTrue(np.array_equal(x[0], features2.point_features[0].data))
-        self.assertTrue(np.array_equal(x[3], features1.point_features[0].data))
-
-    def test_one_label(self):
+    def test_filter_by_label(self):
 
         labels, features1, features2 = self.fixtures(valid_rowcol=True)
-        x, y = load_batch_data(labels, [self.feat_key2, self.feat_key1],
-                               [1], self.feat_loc_template)
+        x, y = load_batch_data(labels, self.feat_loc_template, [1])
 
-        # Both images have two points with label=1
-        self.assertEqual(len(x), 4)
-        self.assertEqual(len(y), 4)
+        for a, b in [
+            (x[0], features1.point_features[0].data),
+            # Missing 1/1
+            (x[1], features1.point_features[2].data),
+            (x[2], features2.point_features[0].data),
+            # Missing 2/1
+            (x[3], features2.point_features[2].data),
+        ]:
+            self.assertTrue(np.array_equal(a, b))
 
 
 if __name__ == '__main__':

--- a/spacer/tests/test_train_utils.py
+++ b/spacer/tests/test_train_utils.py
@@ -114,30 +114,6 @@ class TestTrain(unittest.TestCase):
                 msg="Learning rate init value should correspond to label"
                     " count")
 
-    def test_too_few_classes(self):
-        """ Can't train with only 1 class! """
-        points_per_image = 20
-        feature_dim = 5
-        class_list = [1]
-        num_epochs = 4
-        feature_loc = DataLocation(storage_type='memory', key='')
-
-        train_labels = make_random_data(
-            1, class_list, points_per_image,
-            feature_dim, feature_loc,
-        )
-        ref_labels = make_random_data(
-            1, class_list, points_per_image,
-            feature_dim, feature_loc,
-        )
-
-        for clf_type in config.CLASSIFIER_TYPES:
-            with self.assertRaises(ValueError):
-                train(
-                    train_labels, ref_labels, feature_loc,
-                    num_epochs, clf_type,
-                )
-
 
 class TestEvaluateClassifier(unittest.TestCase):
 
@@ -156,42 +132,11 @@ class TestEvaluateClassifier(unittest.TestCase):
         for clf_type in config.CLASSIFIER_TYPES:
             clf, _ = train(train_data, ref_data, feature_loc, 1, clf_type)
 
-            gts, ests, scores = evaluate_classifier(
-                clf, val_data, class_list, feature_loc)
+            gts, ests, scores = evaluate_classifier(clf, val_data, feature_loc)
             # Sanity checks
             self.assertTrue(all([gt in class_list for gt in gts]))
             self.assertTrue(all([est in class_list for est in ests]))
             self.assertTrue(all([0 < s < 1 for s in scores]))
-
-    def test_no_gt(self):
-        class_list_train_ref = [1, 2]
-        class_list_val = [3]
-        points_per_image = 4
-        feature_dim = 5
-        feature_loc = DataLocation(storage_type='memory', key='')
-        train_data = make_random_data(
-            9, class_list_train_ref, points_per_image,
-            feature_dim, feature_loc)
-        ref_data = make_random_data(
-            1, class_list_train_ref, points_per_image,
-            feature_dim, feature_loc)
-        val_data = make_random_data(
-            3, class_list_val, points_per_image,
-            feature_dim, feature_loc)
-
-        for clf_type in config.CLASSIFIER_TYPES:
-            clf, _ = train(train_data, ref_data, feature_loc, 1, clf_type)
-
-            # Note here that class_list for the val_data doesn't include
-            # any samples from classes [1, 2] so the gt will be empty,
-            # which will raise an exception.
-            with self.assertRaises(ValueError) as cm:
-                evaluate_classifier(
-                    clf, val_data, class_list_train_ref, feature_loc)
-            self.assertEqual(
-                str(cm.exception),
-                "Can't run validation. Validation set has no classes in"
-                " common with the train+ref set.")
 
 
 class TestLoadDataAsMiniBatches(unittest.TestCase):
@@ -220,7 +165,6 @@ class TestLoadDataAsMiniBatches(unittest.TestCase):
                 im_count, self.classes, points_per_image,
                 self.feature_dim, self.feature_loc),
             self.feature_loc,
-            self.classes,
             random_state,
         )]
 
@@ -239,7 +183,6 @@ class TestLoadDataAsMiniBatches(unittest.TestCase):
                 im_count, self.classes, points_per_image,
                 self.feature_dim, self.feature_loc),
             self.feature_loc,
-            self.classes,
             random_state,
         )]
 
@@ -258,7 +201,6 @@ class TestLoadDataAsMiniBatches(unittest.TestCase):
                 im_count, self.classes, points_per_image,
                 self.feature_dim, self.feature_loc),
             self.feature_loc,
-            self.classes,
             random_state,
         )]
 
@@ -288,7 +230,6 @@ class TestLoadDataAsMiniBatches(unittest.TestCase):
                 im_count, self.classes, points_per_image,
                 self.feature_dim, self.feature_loc),
             self.feature_loc,
-            self.classes,
             random_state,
         )]
 
@@ -314,13 +255,11 @@ class TestLoadDataAsMiniBatches(unittest.TestCase):
         batches_1 = [batch for batch in load_data_as_mini_batches(
             data,
             self.feature_loc,
-            self.classes,
             random_state,
         )]
         batches_2 = [batch for batch in load_data_as_mini_batches(
             data,
             self.feature_loc,
-            self.classes,
             random_state,
         )]
 
@@ -392,7 +331,7 @@ class TestLoadImageData(unittest.TestCase):
 
         labels, features = self.fixtures(in_order=True)
 
-        x, y = zip(*load_image_data(labels, self.feature_loc, [1, 2]))
+        x, y = zip(*load_image_data(labels, self.feature_loc))
 
         self.assertEqual(list(y), [1, 2, 1])
         self.assertTrue(np.array_equal(x[0], features.point_features[0].data))
@@ -404,7 +343,7 @@ class TestLoadImageData(unittest.TestCase):
         """
         labels, features = self.fixtures(in_order=False)
 
-        x, y = zip(*load_image_data(labels, self.feature_loc, [1, 2]))
+        x, y = zip(*load_image_data(labels, self.feature_loc))
 
         self.assertEqual(list(y), [1, 2, 1])
         # Same elements, different order relative to features.
@@ -419,7 +358,7 @@ class TestLoadImageData(unittest.TestCase):
         """
         labels, features = self.fixtures(in_order=False, valid_rowcol=False)
 
-        x, y = zip(*load_image_data(labels, self.feature_loc, [1, 2]))
+        x, y = zip(*load_image_data(labels, self.feature_loc))
 
         self.assertEqual(list(y), [1, 2, 1])
         # There should have been no attempt to correct the order
@@ -427,49 +366,6 @@ class TestLoadImageData(unittest.TestCase):
         self.assertTrue(np.array_equal(x[0], features.point_features[0].data))
         self.assertTrue(np.array_equal(x[1], features.point_features[1].data))
         self.assertTrue(np.array_equal(x[2], features.point_features[2].data))
-
-    def test_smaller_labelset(self):
-        """
-        Here we use a smaller labelset and assert
-        that the right features are kept
-        """
-
-        labels, features = self.fixtures(in_order=True, valid_rowcol=True)
-
-        x, y = zip(*load_image_data(labels, self.feature_loc, [1]))
-
-        self.assertEqual(list(y), [1, 1])
-        # Just the 1st and 3rd point features
-        self.assertTrue(np.array_equal(x[0], features.point_features[0].data))
-        self.assertTrue(np.array_equal(x[1], features.point_features[2].data))
-
-    def test_other_small_labelset(self):
-        """
-        Here we use a smaller labelset and assert
-        that the right features are kept
-        """
-
-        labels, features = self.fixtures(in_order=True, valid_rowcol=True)
-
-        x, y = zip(*load_image_data(labels, self.feature_loc, [2]))
-
-        self.assertEqual(list(y), [2])
-        # Just the 2nd point feature
-        self.assertTrue(np.array_equal(x[0], features.point_features[1].data))
-
-    def test_legacy_smaller_labelset(self):
-        """
-        Here we pretend the features are legacy such that row, col
-        information is not available.
-        """
-        labels, features = self.fixtures(in_order=True, valid_rowcol=False)
-
-        x, y = zip(*load_image_data(labels, self.feature_loc, [1]))
-
-        self.assertEqual(list(y), [1, 1])
-        # Just the 1st and 3rd point features
-        self.assertTrue(np.array_equal(x[0], features.point_features[0].data))
-        self.assertTrue(np.array_equal(x[1], features.point_features[2].data))
 
     def test_rowcol_mismatch(self):
         """
@@ -480,7 +376,7 @@ class TestLoadImageData(unittest.TestCase):
         labels[2] = (300, 299, 1)
 
         with self.assertRaises(RowColumnMismatchError) as cm:
-            _, _ = load_image_data(labels, self.feature_loc, [1, 2])
+            _, _ = load_image_data(labels, self.feature_loc)
         self.assertEqual(
             str(cm.exception),
             f"{self.feat_key}: The labels' row-column positions don't match"
@@ -496,7 +392,7 @@ class TestLoadImageData(unittest.TestCase):
         labels.append((400, 400, 2))
 
         with self.assertRaises(RowColumnMismatchError) as cm:
-            _, _ = load_image_data(labels, self.feature_loc, [1, 2])
+            _, _ = load_image_data(labels, self.feature_loc)
         self.assertEqual(
             str(cm.exception),
             f"{self.feat_key}: The number of labels (4) doesn't match"
@@ -556,7 +452,7 @@ class TestLoadBatchData(unittest.TestCase):
     def test_simple(self):
 
         labels, features1, features2 = self.fixtures(valid_rowcol=True)
-        x, y = load_batch_data(labels, self.feat_loc_template, [1, 2])
+        x, y = load_batch_data(labels, self.feat_loc_template)
 
         for a, b in [
             (x[0], features1.point_features[0].data),
@@ -565,21 +461,6 @@ class TestLoadBatchData(unittest.TestCase):
             (x[3], features2.point_features[0].data),
             (x[4], features2.point_features[1].data),
             (x[5], features2.point_features[2].data),
-        ]:
-            self.assertTrue(np.array_equal(a, b))
-
-    def test_filter_by_label(self):
-
-        labels, features1, features2 = self.fixtures(valid_rowcol=True)
-        x, y = load_batch_data(labels, self.feat_loc_template, [1])
-
-        for a, b in [
-            (x[0], features1.point_features[0].data),
-            # Missing 1/1
-            (x[1], features1.point_features[2].data),
-            (x[2], features2.point_features[0].data),
-            # Missing 2/1
-            (x[3], features2.point_features[2].data),
         ]:
             self.assertTrue(np.array_equal(a, b))
 

--- a/spacer/train_classifier.py
+++ b/spacer/train_classifier.py
@@ -9,8 +9,9 @@ import time
 from sklearn.calibration import CalibratedClassifierCV
 
 from spacer import config
-from spacer.data_classes import ImageLabels, ValResults
-from spacer.messages import TrainClassifierReturnMsg, DataLocation
+from spacer.data_classes import ValResults
+from spacer.messages import (
+    DataLocation, TrainClassifierReturnMsg, TrainingTaskLabels)
 from spacer.train_utils import train, evaluate_classifier, calc_acc
 
 
@@ -18,7 +19,7 @@ class ClassifierTrainer(abc.ABC):  # pragma: no cover
 
     @abc.abstractmethod
     def __call__(self,
-                 labels: dict[str, ImageLabels],
+                 labels: TrainingTaskLabels,
                  nbr_epochs: int,
                  pc_models: list[CalibratedClassifierCV],
                  feature_loc: DataLocation,
@@ -51,13 +52,13 @@ class MiniBatchTrainer(ClassifierTrainer):
 
         # Evaluate new classifier on validation set.
         val_gts, val_ests, val_scores = evaluate_classifier(
-            clf, labels['val'], classes, feature_loc)
+            clf, labels['val'], feature_loc)
 
         # Evaluate previous classifiers on validation set.
         pc_accs = []
         for pc_model in pc_models:
             pc_gts, pc_ests, _ = evaluate_classifier(
-                pc_model, labels['val'], classes, feature_loc)
+                pc_model, labels['val'], feature_loc)
             pc_accs.append(calc_acc(pc_gts, pc_ests))
 
         return \

--- a/spacer/train_utils.py
+++ b/spacer/train_utils.py
@@ -91,7 +91,7 @@ def evaluate_classifier(clf: CalibratedClassifierCV,
     for image_key in labels.image_keys:
 
         feature_loc.key = image_key
-        image_labels_data = labels.data[image_key]
+        image_labels_data = labels[image_key]
 
         pairs = list(
             load_image_data(image_labels_data, feature_loc))
@@ -135,7 +135,7 @@ def load_batch_data(labels: ImageLabels,
     for image_key in labels.image_keys:
 
         feature_loc.key = image_key
-        image_labels_data = labels.data[image_key]
+        image_labels_data = labels[image_key]
 
         batch.extend(
             load_image_data(image_labels_data, feature_loc))
@@ -174,7 +174,7 @@ def load_data_as_mini_batches(labels: ImageLabels,
     for image_key in image_keys:
 
         feature_loc.key = image_key
-        image_labels_data = labels.data[image_key]
+        image_labels_data = labels[image_key]
 
         for point_feature, label in load_image_data(
                 image_labels_data, feature_loc):

--- a/spacer/train_utils.py
+++ b/spacer/train_utils.py
@@ -33,9 +33,6 @@ def train(train_labels: ImageLabels,
           nbr_epochs: int,
           clf_type: str) -> tuple[CalibratedClassifierCV, list[float]]:
 
-    if len(train_labels) < config.MIN_TRAINIMAGES:
-        raise ValueError('Not enough training samples.')
-
     logger.debug(
         f"Data sets:"
         f" Train = {len(train_labels)} images,"

--- a/spacer/train_utils.py
+++ b/spacer/train_utils.py
@@ -5,6 +5,7 @@ Utility methods for training classifiers.
 from __future__ import annotations
 import random
 import string
+from collections.abc import Generator
 from logging import getLogger
 
 import numpy as np
@@ -20,69 +21,68 @@ from spacer.messages import DataLocation
 logger = getLogger(__name__)
 
 
-def train(labels: ImageLabels,
+# Implicit type alias; revisit in Python 3.10
+# https://peps.python.org/pep-0613/
+FeatureLabelPair = tuple[np.ndarray, int]
+FeatureLabelBatch = tuple[list[np.ndarray], list[int]]
+
+
+def train(train_labels: ImageLabels,
+          ref_labels: ImageLabels,
           feature_loc: DataLocation,
           nbr_epochs: int,
           clf_type: str) -> tuple[CalibratedClassifierCV, list[float]]:
 
-    if len(labels) < config.MIN_TRAINIMAGES:
+    if len(train_labels) < config.MIN_TRAINIMAGES:
         raise ValueError('Not enough training samples.')
 
-    # Calculate max nbr images to keep in memory (for 5000 samples total).
-    max_imgs_in_memory = 5000 // labels.samples_per_image
+    logger.debug(
+        f"Data sets:"
+        f" Train = {len(train_labels)} images,"
+        f" {train_labels.label_count} labels;"
+        f" Ref = {len(ref_labels)} images,"
+        f" {ref_labels.label_count} labels")
+    logger.debug(
+        f"Mini-batch size: {config.TRAINING_BATCH_LABEL_COUNT} labels")
 
-    # Make train and ref split.
-    # Reference set is here a hold-out part of the train-data portion.
-    # Purpose of reference set is to
-    # 1) know accuracy per epoch
-    # 2) calibrate classifier output scores.
-    # We call it "reference" to disambiguate from the validation set.
-    ref_set = labels.image_keys[::10]
-    np.random.shuffle(ref_set)
-    ref_set = ref_set[:max_imgs_in_memory]  # Enforce memory limit.
-    train_set = list(set(labels.image_keys) - set(ref_set))
-    logger.debug("Trainset: {}, valset: {} images".
-                 format(len(train_set), len(ref_set)))
-
-    # Figure out # images per batch and batches per epoch.
-    images_per_batch, batches_per_epoch = \
-        calc_batch_size(max_imgs_in_memory, len(train_set))
-    logger.debug("Using {} images per mini-batch and {} mini-batches per "
-                 "epoch".format(images_per_batch, batches_per_epoch))
-
-    # Identify classes common to both train and val.
+    # Identify classes common to both train and ref.
     # This will be our labelset for the training.
-    trainclasses = labels.unique_classes(train_set)
-    refclasses = labels.unique_classes(ref_set)
-    classes = list(trainclasses.intersection(refclasses))
-    logger.debug("Trainset: {}, valset: {}, common: {} labels".format(
-        len(trainclasses), len(refclasses), len(classes)))
-    if len(classes) == 1:
-        raise ValueError('Not enough classes to do training (only 1)')
+    train_classes = train_labels.unique_classes()
+    ref_classes = ref_labels.unique_classes()
+    classes = list(train_classes.intersection(ref_classes))
+    logger.debug(
+        f"Unique classes: Train = {len(train_classes)},"
+        f" Ref = {len(ref_classes)}, common = {len(classes)}")
+    if len(classes) <= 1:
+        raise ValueError(
+            f"Need multiple classes to do training (there are {len(classes)})")
 
     # Load reference data (must hold in memory for the calibration)
     with config.log_entry_and_exit("loading of reference data"):
-        refx, refy = load_batch_data(labels, ref_set, classes, feature_loc)
+        refx, refy = load_batch_data(ref_labels, feature_loc, classes)
 
     # Initialize classifier and ref set accuracy list
     with config.log_entry_and_exit("training using " + clf_type):
         if clf_type == 'MLP':
-            if len(train_set) * labels.samples_per_image >= 50000:
+            if train_labels.label_count >= 50000:
                 hls, lr = (200, 100), 1e-4
             else:
                 hls, lr = (100,), 1e-3
             clf = MLPClassifier(hidden_layer_sizes=hls, learning_rate_init=lr)
         else:
             clf = SGDClassifier(loss='log_loss', average=True, random_state=0)
+
         ref_acc = []
+
         for epoch in range(nbr_epochs):
-            np.random.shuffle(train_set)
-            mini_batches = chunkify(train_set, batches_per_epoch)
-            for mb in mini_batches:
-                x, y = load_batch_data(labels, mb, classes, feature_loc)
+            for x, y in load_data_as_mini_batches(
+                labels=train_labels, feature_loc=feature_loc,
+                classes=classes, random_state=epoch,
+            ):
                 clf.partial_fit(x, y, classes=classes)
+
             ref_acc.append(calc_acc(refy, clf.predict(refx)))
-            logger.debug("Epoch {}, acc: {}".format(epoch, ref_acc[-1]))
+            logger.debug(f"Epoch {epoch}, acc: {ref_acc[-1]}")
 
     with config.log_entry_and_exit("calibration"):
         clf_calibrated = CalibratedClassifierCV(clf, cv="prefit")
@@ -97,110 +97,166 @@ def evaluate_classifier(clf: CalibratedClassifierCV,
                         feature_loc: DataLocation) -> tuple[list, list, list]:
     """ Evaluates classifier on data """
     scores, gts, ests = [], [], []
-    for imkey in labels.image_keys:
-        x, y = load_image_data(labels, imkey, classes, feature_loc)
-        if len(x) > 0:
-            scores.extend(clf.predict_proba(x).max(axis=1).tolist())
-            ests.extend(clf.predict(x))
-            gts.extend(y)
+
+    for image_key in labels.image_keys:
+
+        feature_loc.key = image_key
+        image_labels_data = labels.data[image_key]
+
+        pairs = list(
+            load_image_data(image_labels_data, feature_loc, classes))
+        if len(pairs) == 0:
+            # None of the labels for this image overlap with classes.
+            continue
+
+        # List of pairs -> pair of lists
+        x, y = zip(*pairs)
+
+        scores.extend(clf.predict_proba(x).max(axis=1).tolist())
+        ests.extend(clf.predict(x))
+        gts.extend(y)
 
     if len(gts) == 0:
-        raise ValueError('Not enough data in validation set.')
+        raise ValueError(
+            "Can't run validation. Validation set has no classes in"
+            " common with the train+ref set.")
 
     return gts, ests, scores
 
 
-def chunkify(lst: list,
-             nbr_chunks: int) -> list:
-    return [lst[i::nbr_chunks] for i in range(nbr_chunks)]
-
-
-def calc_batch_size(max_imgs_in_memory: int,
-                    train_set_size: int) -> tuple[int, int]:
-    images_per_batch = min(max_imgs_in_memory, train_set_size)
-    batches_per_epoch = int(np.ceil(train_set_size / images_per_batch))
-    return images_per_batch, batches_per_epoch
-
-
-def load_image_data(labels: ImageLabels,
-                    imkey: str,
-                    classes: list[int],
-                    feature_loc: DataLocation) \
-        -> tuple[list[list[float]], list[int]]:
+def load_image_data(labels_data: list[tuple[int, int, int]],
+                    feature_loc: DataLocation,
+                    classes: list[int]) \
+        -> Generator[FeatureLabelPair, None, None]:
     """
-    Loads features and labels for the specified image,
-    and builds element-matching lists for use with methods such as
-    CalibratedClassifierCV.fit().
+    Loads a feature vector and labels of a single image, and generates
+    element-matching pairs.
     """
+    # Load features.
+    features = ImageFeatures.load(feature_loc)
 
-    # Load features for this image.
-    feature_loc.key = imkey
-    image_features = ImageFeatures.load(feature_loc)
+    for point_feature, label in match_features_and_labels(
+            features, labels_data, feature_loc.key):
 
-    # Load row, col, labels for this image.
-    image_labels = labels.data[imkey]
+        if label not in classes:
+            continue
+
+        yield point_feature, label
+
+
+def load_batch_data(labels: ImageLabels,
+                    feature_loc: DataLocation,
+                    # Only load labels of these classes.
+                    classes: list[int]) \
+        -> FeatureLabelBatch:
+    """
+    Loads features and labels, and builds element-matching lists
+    for use with methods such as CalibratedClassifierCV.fit().
+    """
+    batch = []
+
+    for image_key in labels.image_keys:
+
+        feature_loc.key = image_key
+        image_labels_data = labels.data[image_key]
+
+        batch.extend(
+            load_image_data(image_labels_data, feature_loc, classes))
+
+    assert (
+        len(batch) > 0,
+        "We only ever expect labels to be a non-empty ref set.")
+
+    # List of pairs -> pair of lists
+    x, y = zip(*batch)
+    return x, y
+
+
+def load_data_as_mini_batches(labels: ImageLabels,
+                              feature_loc: DataLocation,
+                              # Only load labels of these classes.
+                              classes: list[int],
+                              # For seeding the randomizer to get repeatable
+                              # results.
+                              random_state: int) \
+        -> Generator[FeatureLabelBatch, None, None]:
+    """
+    Loads features and labels, and generates batches of
+    element-matching pairs.
+
+    Since this is a generator, it does not have to load all feature
+    vectors in memory at the same time; only as many as will fit in
+    a batch.
+    Note that a single image's features may straddle multiple batches.
+    """
+    image_keys = labels.image_keys
+
+    # Shuffle the order of images.
+    np.random.seed(random_state)
+    np.random.shuffle(image_keys)
+
+    current_batch = []
+
+    for image_key in image_keys:
+
+        feature_loc.key = image_key
+        image_labels_data = labels.data[image_key]
+
+        for point_feature, label in load_image_data(
+                image_labels_data, feature_loc, classes):
+
+            current_batch.append((point_feature, label))
+
+            if len(current_batch) >= config.TRAINING_BATCH_LABEL_COUNT:
+                # List of pairs -> pair of lists
+                x, y = zip(*current_batch)
+                yield x, y
+                current_batch = []
+
+    if len(current_batch) > 0:
+        # Last batch
+        x, y = zip(*current_batch)
+        yield x, y
+
+
+def match_features_and_labels(features: ImageFeatures,
+                              labels_data: list[tuple[int, int, int]],
+                              image_key: str) \
+        -> Generator[FeatureLabelPair, None, None]:
 
     # Sanity check
-    if image_features.valid_rowcol:
+    if features.valid_rowcol:
         # With new data structure just check that the sets of row, col
         # given by the labels are available in the features.
         rc_features_set = set([(pf.row, pf.col) for pf in
-                               image_features.point_features])
-        rc_labels_set = set([(row, col) for (row, col, _) in image_labels])
+                               features.point_features])
+        rc_labels_set = set([(row, col) for (row, col, _) in labels_data])
 
         if not rc_labels_set.issubset(rc_features_set):
             difference_set = rc_labels_set.difference(rc_features_set)
             example_rc = next(iter(difference_set))
             raise RowColumnMismatchError(
-                f"{imkey}: The labels' row-column positions don't match those"
-                f" of the feature vector (example: {example_rc}).")
+                f"{image_key}: The labels' row-column positions don't match"
+                f" those of the feature vector (example: {example_rc}).")
     else:
         # With legacy data structure check that length is the same.
-        label_count = len(image_labels)
-        feature_count = len(image_features.point_features)
+        label_count = len(labels_data)
+        feature_count = len(features.point_features)
 
         if not label_count == feature_count:
             raise RowColumnMismatchError(
-                f"{imkey}: The number of labels ({label_count}) doesn't match"
-                f" the number of extracted features ({feature_count}).")
+                f"{image_key}: The number of labels ({label_count}) doesn't"
+                f" match the number of extracted features ({feature_count}).")
 
-    x, y = [], []
-    if image_features.valid_rowcol:
-        for row, col, label in image_labels:
-            if label not in classes:
-                # Remove samples for which the label is not in classes.
-                continue
-            x.append(image_features[(row, col)])
-            y.append(label)
-
+    if features.valid_rowcol:
+        for row, col, label in labels_data:
+            yield features[(row, col)], label
     else:
         # For legacy features, we didn't store the row, col information.
         # Instead rely on ordering.
-        for (_, _, label), point_feature in zip(image_labels,
-                                                image_features.point_features):
-            if label not in classes:
-                continue
-            x.append(point_feature.data)
-            y.append(label)
-
-    return x, y
-
-
-def load_batch_data(labels: ImageLabels,
-                    imkeylist: list[str],
-                    classes: list[int],
-                    feature_loc: DataLocation) \
-        -> tuple[list[list[float]], list[int]]:
-    """
-    Builds element-matching lists of features and labels
-    for multiple images.
-    """
-    x, y = [], []
-    for imkey in imkeylist:
-        x_, y_ = load_image_data(labels, imkey, classes, feature_loc)
-        x.extend(x_)
-        y.extend(y_)
-    return x, y
+        for (_, _, label), point_feature in zip(labels_data,
+                                                features.point_features):
+            yield point_feature.data, label
 
 
 def calc_acc(gt: list[int], est: list[int]) -> float:
@@ -233,7 +289,7 @@ def make_random_data(im_count: int,
     Utility method for testing that generates an ImageLabels instance
     complete with stored ImageFeatures.
     """
-    labels = ImageLabels(data={})
+    data = {}
     for _ in range(im_count):
 
         # Generate random features (using labels to draw from a Gaussian).
@@ -250,8 +306,8 @@ def make_random_data(im_count: int,
         # Store
         feature_loc.key = imkey
         feats.store(feature_loc)
-        labels.data[imkey] = [
+        data[imkey] = [
             (pf.row, pf.col, pl) for pf, pl in
             zip(feats.point_features, point_labels)
         ]
-    return labels
+    return ImageLabels(data)

--- a/spacer/train_utils.py
+++ b/spacer/train_utils.py
@@ -7,6 +7,7 @@ import random
 import string
 from collections.abc import Generator
 from logging import getLogger
+from typing import List, Tuple
 
 import numpy as np
 from sklearn.calibration import CalibratedClassifierCV
@@ -23,8 +24,8 @@ logger = getLogger(__name__)
 
 # Implicit type alias; revisit in Python 3.10
 # https://peps.python.org/pep-0613/
-FeatureLabelPair = tuple[np.ndarray, int]
-FeatureLabelBatch = tuple[list[np.ndarray], list[int]]
+FeatureLabelPair = Tuple[np.ndarray, int]
+FeatureLabelBatch = Tuple[List[np.ndarray], List[int]]
 
 
 def train(train_labels: ImageLabels,


### PR DESCRIPTION
For issue #60.

- Training labels are now specified either as just one set, or as train + reference + val sets.
- Training mini-batch size is now configurable as `TRAINING_BATCH_LABEL_COUNT`.
- Training mini-batch size is now followed more accurately, rather than approximating based on number of labels in the first image.

Note: I'll probably end up amending commit 813a17b to update tests / fix any bugs.