### PR TITLE
Use newer type hint syntax

### DIFF
--- a/scripts/aws/batch_simple.py
+++ b/scripts/aws/batch_simple.py
@@ -2,13 +2,13 @@
 This script submits 10 jobs to queues and monitors as the
 jobs are completed.
 """
+from __future__ import annotations
 import logging
-from typing import List
 
 from scripts.aws.utils import submit_jobs, monitor_jobs
 
 
-def main(nbr_rowcols: List[int],
+def main(nbr_rowcols: list[int],
          job_queue: str = 'shakeout',
          image_size: int = 1000):
 

--- a/scripts/aws/utils.py
+++ b/scripts/aws/utils.py
@@ -1,10 +1,9 @@
+from __future__ import annotations
 import json
 import logging
 import time
 from collections import defaultdict
 from datetime import datetime
-from typing import List
-from typing import Tuple
 
 import boto3
 import numpy as np
@@ -42,7 +41,7 @@ def aws_batch_submit(job_queue: str,
     return resp['jobId']
 
 
-def aws_batch_job_status(jobs: List[Tuple[str, DataLocation, JobMsg,
+def aws_batch_job_status(jobs: list[tuple[str, DataLocation, JobMsg,
                                           DataLocation, DataLocation, int]]):
     """ Monitor AWS batch status.
     Input should be tuple same as the output of submit_jobs
@@ -96,7 +95,7 @@ def aws_batch_job_status(jobs: List[Tuple[str, DataLocation, JobMsg,
     return state, runtimes
 
 
-def submit_jobs(nbr_rowcols: List[int],
+def submit_jobs(nbr_rowcols: list[int],
                 job_queue: str = 'shakeout',
                 image_size: int = 1000,
                 extractor_name: str = 'efficientnet_b0_ver1'):

--- a/scripts/regression/utils.py
+++ b/scripts/regression/utils.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
 import glob
 import json
 import os
 import random
-from typing import Tuple
 
 import tqdm
 
@@ -50,7 +50,7 @@ def cache_local(source_root: str,
             bucket.Object(obj.key).download_file(local_path)
 
 
-def build_traindata(image_root: str) -> Tuple[ImageLabels, ImageLabels]:
+def build_traindata(image_root: str) -> tuple[ImageLabels, ImageLabels]:
 
     print('Assembling data in {}...'.format(image_root))
     # Create the train and val ImageLabels data structures.

--- a/spacer/caffe_utils.py
+++ b/spacer/caffe_utils.py
@@ -4,9 +4,10 @@ simplicity. Since support for Caffe will be deprecate,
 these are only lightly cleaned up from their original state.
 """
 
+from __future__ import annotations
 from copy import copy
 from functools import lru_cache
-from typing import List, Any, Tuple
+from typing import Any
 
 import caffe
 import numpy as np
@@ -21,7 +22,7 @@ class Transformer:
     (scaling and mean subtraction.).
     """
 
-    def __init__(self, mean: Tuple = (0, 0, 0)) -> None:
+    def __init__(self, mean: tuple = (0, 0, 0)) -> None:
         self.mean = np.array(mean, dtype=np.float32)
         self.scale = 1.0
 
@@ -54,12 +55,12 @@ class Transformer:
         return np.uint8(im)
 
 
-def classify_from_imlist(im_list: List,
+def classify_from_imlist(im_list: list,
                          net: Any,
                          transformer: Transformer,
                          batch_size: int,
                          scorelayer: str = 'score',
-                         startlayer: str = 'conv1_1') -> List:
+                         startlayer: str = 'conv1_1') -> list:
     """
     classify_from_imlist classifies a list of images and returns
     estimated labels and scores.
@@ -101,12 +102,12 @@ def load_net(modeldef_path: str,
     return caffe.Net(modeldef_path, modelweighs_path, caffe.TEST)
 
 
-def classify_from_patchlist(patchlist: List,
+def classify_from_patchlist(patchlist: list,
                             pyparams: dict,
                             modeldef_path: str,
                             modelweighs_path: str,
                             scorelayer: str = 'score',
-                            startlayer: str = 'conv1_1') -> List:
+                            startlayer: str = 'conv1_1') -> list:
     """
     extract features of a list of patches
     :param patchlist: a list of patches (cropped images).

--- a/spacer/config.py
+++ b/spacer/config.py
@@ -2,6 +2,7 @@
 Contains config and settings for the repo.
 """
 
+from __future__ import annotations
 import importlib
 import json
 import logging
@@ -11,7 +12,7 @@ import time
 import warnings
 from contextlib import ContextDecorator
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import boto3
 from PIL import Image, ImageFile
@@ -51,7 +52,7 @@ if SECRETS_PATH.exists():
 #     'AWS_ACCESS_KEY_ID': '...',
 #     'AWS_SECRET_ACCESS_KEY': '...',
 # }
-SETTINGS_FROM_DJANGO: Optional[dict] = None
+SETTINGS_FROM_DJANGO: dict | None = None
 try:
     from django.core.exceptions import ImproperlyConfigured
 except ImportError:

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -3,11 +3,11 @@ Defines data-classes for input and output types.
 Each data-class can serialize itself to a structure of JSON-friendly
 python-native data-structures such that it can be stored.
 """
+from __future__ import annotations
 import json
 from abc import ABC, abstractmethod
 from io import BytesIO
 from pprint import pformat
-from typing import Dict, List, Tuple, Set, Optional, Union
 
 import numpy as np
 
@@ -36,14 +36,14 @@ class DataClass(ABC):  # pragma: no cover
         """
 
     @classmethod
-    def deserialize(cls, data: Dict) -> 'DataClass':
+    def deserialize(cls, data: dict) -> 'DataClass':
         """
         Initializes a class instance from input data.
         Input should be a dictionary containing native python data structures.
         """
         return cls(**data)
 
-    def serialize(self) -> Dict:
+    def serialize(self) -> dict:
         """
         Serialized the class content to native data-types, dicts, lists, etc,
         such that it it compatible with json.dumps and json.loads.
@@ -66,12 +66,12 @@ class DataClass(ABC):  # pragma: no cover
 
 
 class ImageLabels(DataClass):
-    """ Contains row, col, label information for an image. """
+    """ Contains row, col, label information for a set of images. """
 
     def __init__(self,
                  # Data maps a feature key (or file path) to a List of
                  # (row, col, label).
-                 data: Dict[str, List[Tuple[int, int, int]]]):
+                 data: dict[str, list[tuple[int, int, int]]]):
         self.data = data
 
     @classmethod
@@ -84,7 +84,7 @@ class ImageLabels(DataClass):
         })
 
     @classmethod
-    def deserialize(cls, data: Dict) -> 'ImageLabels':
+    def deserialize(cls, data: dict) -> 'ImageLabels':
         """ Custom deserializer required to convert back to tuples. """
         return ImageLabels(
             data={key: [tuple(entry) for entry in value] for
@@ -98,7 +98,7 @@ class ImageLabels(DataClass):
     def samples_per_image(self):
         return len(next(iter(self.data.values())))
 
-    def unique_classes(self, key_list: List[str]) -> Set[int]:
+    def unique_classes(self, key_list: list[str]) -> set[int]:
         """ Returns the set of all unique classes in the key_list subset. """
         labels = set()
         for im_key in key_list:
@@ -113,8 +113,8 @@ class PointFeatures(DataClass):
     """ Contains row, col, feature-vector for a single point. """
 
     def __init__(self,
-                 row: Optional[int],  # Row where feature was extracted
-                 col: Optional[int],  # Column where feature was extracted
+                 row: int | None,  # Row where feature was extracted
+                 col: int | None,  # Column where feature was extracted
                  data: np.array,  # Feature vector with 32 bit precision.
                  ):
         self.row = row
@@ -139,7 +139,7 @@ class ImageFeatures(DataClass):
 
     def __init__(self,
                  # List of features for all points in image
-                 point_features: List[PointFeatures],
+                 point_features: list[PointFeatures],
                  # Legacy feature did not store row and column locations.
                  valid_rowcol: bool,
                  # Dimensionality of the feature vectors.
@@ -162,13 +162,13 @@ class ImageFeatures(DataClass):
             self._rchash = {(pf.row, pf.col): enum for
                             enum, pf in enumerate(self.point_features)}
 
-    def __getitem__(self, rowcol: Tuple[int, int]) -> List[float]:
+    def __getitem__(self, rowcol: tuple[int, int]) -> list[float]:
         """ Returns features at (row, col) location. """
         if not self.valid_rowcol:
             raise ValueError('Method not supported for legacy features')
         return self.point_features[self._rchash[rowcol]].data
 
-    def get_array(self, rowcol: Tuple[int, int]) -> np.array:
+    def get_array(self, rowcol: tuple[int, int]) -> np.array:
         """
         Similar to __getitem__ but returns a numpy array formatted
         correctly for classification by a classifier of type
@@ -188,9 +188,9 @@ class ImageFeatures(DataClass):
         )
 
     @classmethod
-    def deserialize(cls, data: Union[Dict, List]) -> 'ImageFeatures':
+    def deserialize(cls, data: dict | list) -> 'ImageFeatures':
 
-        assert isinstance(data, List), \
+        assert isinstance(data, list), \
             "Deserialize only supported for legacy format"
         # Legacy feature were stored as a list of list
         # without row and column information.
@@ -216,7 +216,7 @@ class ImageFeatures(DataClass):
 
     @classmethod
     def make_random(cls,
-                    point_labels: List[int],
+                    point_labels: list[int],
                     feature_dim: int):
         pfs = [PointFeatures(row=itt,
                              col=itt,
@@ -259,8 +259,10 @@ class ImageFeatures(DataClass):
     def store(self, loc: 'DataLocation'):
         storage = storage_factory(loc.storage_type, loc.bucket_name)
         if self.valid_rowcol:
-            rows = np.array([p.row for p in self.point_features], dtype=np.uint16)
-            cols = np.array([p.col for p in self.point_features], dtype=np.uint16)
+            rows = np.array(
+                [p.row for p in self.point_features], dtype=np.uint16)
+            cols = np.array(
+                [p.col for p in self.point_features], dtype=np.uint16)
         else:
             rows = np.array([])
             cols = np.array([])
@@ -277,10 +279,10 @@ class ValResults(DataClass):
     lists points to the index into the classes list."""
 
     def __init__(self,
-                 scores: List[float],
-                 gt: List[int],  # Using singular for backwards compatibility.
-                 est: List[int],  # Using singular for backwards compatibility.
-                 classes: List[int]):
+                 scores: list[float],
+                 gt: list[int],  # Using singular for backwards compatibility.
+                 est: list[int],  # Using singular for backwards compatibility.
+                 classes: list[int]):
 
         assert len(gt) == len(est)
         assert len(gt) == len(scores)
@@ -302,6 +304,6 @@ class ValResults(DataClass):
                    classes=[121, 1222])
 
     @classmethod
-    def deserialize(cls, data: Dict) -> 'ValResults':
+    def deserialize(cls, data: dict) -> 'ValResults':
         """ Redefined here to help the Typing module. """
         return ValResults(**data)

--- a/spacer/extract_features_utils.py
+++ b/spacer/extract_features_utils.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from __future__ import annotations
 
 import numpy as np
 from PIL import Image
@@ -20,8 +20,8 @@ def gray2rgb(im: np.ndarray) -> np.ndarray:
 
 
 def crop_patches(im: Image,
-                 rowcols: List[Tuple[int, int]],
-                 crop_size: int) -> List[np.ndarray]:
+                 rowcols: list[tuple[int, int]],
+                 crop_size: int) -> list[np.ndarray]:
     """
     Crop patches from an image
     :param im: image for cropping
@@ -45,7 +45,7 @@ def crop_patches(im: Image,
 
 
 def crop_simple(im: np.ndarray,
-                center: Tuple[int, int],
+                center: tuple[int, int],
                 crop_size: int) -> np.ndarray:
     """
     Crops an image around the given center

--- a/spacer/storage.py
+++ b/spacer/storage.py
@@ -2,6 +2,7 @@
 Defines storage ABC; implementations; and factory.
 """
 
+from __future__ import annotations
 import abc
 import os
 import pickle
@@ -10,7 +11,6 @@ from functools import lru_cache
 from http.client import IncompleteRead
 from io import BytesIO
 from pickle import Unpickler
-from typing import Union
 from urllib.error import URLError
 import urllib.request
 
@@ -178,7 +178,7 @@ def clear_memory_storage():
     _memorystorage = None
 
 
-def storage_factory(storage_type: str, bucketname: Union[str, None] = None):
+def storage_factory(storage_type: str, bucketname: str | None = None):
 
     assert storage_type in config.STORAGE_TYPES
 

--- a/spacer/tests/test_train_utils.py
+++ b/spacer/tests/test_train_utils.py
@@ -1,6 +1,6 @@
+from __future__ import annotations
 import itertools
 import unittest
-from typing import Tuple
 
 import numpy as np
 
@@ -217,7 +217,7 @@ class TestLoadImageData(unittest.TestCase):
                                         key=self.feat_key)
 
     def fixtures(self, in_order=True, valid_rowcol=True) \
-            -> Tuple[ImageLabels, ImageFeatures]:
+            -> tuple[ImageLabels, ImageFeatures]:
 
         labels = ImageLabels(
             data={self.feat_key: [(100, 100, 1),
@@ -371,7 +371,7 @@ class TestLoadBatchData(unittest.TestCase):
         self.feat_loc_template = DataLocation(storage_type='memory', key='')
 
     def fixtures(self, valid_rowcol=True) \
-            -> Tuple[ImageLabels, ImageFeatures, ImageFeatures]:
+            -> tuple[ImageLabels, ImageFeatures, ImageFeatures]:
 
         labels = ImageLabels(
             data={self.feat_key1: [(100, 100, 1),

--- a/spacer/torch_utils.py
+++ b/spacer/torch_utils.py
@@ -2,10 +2,10 @@
 This file contains a set of pytorch utility functions
 """
 
-import hashlib
+from __future__ import annotations
 from collections import OrderedDict
 from io import BytesIO
-from typing import Any, List
+from typing import Any
 
 import numpy as np
 import torch
@@ -52,8 +52,8 @@ def load_weights(model: Any,
     return model
 
 
-def extract_feature(patch_list: List,
-                    pyparams: dict) -> List:
+def extract_feature(patch_list: list,
+                    pyparams: dict) -> list:
     """
     Crop patches and extract features
     :param patch_list: a list of cropped images

--- a/spacer/train_classifier.py
+++ b/spacer/train_classifier.py
@@ -2,9 +2,9 @@
 Defines train-classifier ABC; implementations; and factory.
 """
 
+from __future__ import annotations
 import abc
 import time
-from typing import Tuple, List
 
 from sklearn.calibration import CalibratedClassifierCV
 
@@ -21,10 +21,10 @@ class ClassifierTrainer(abc.ABC):  # pragma: no cover
                  train_labels: ImageLabels,
                  val_labels: ImageLabels,
                  nbr_epochs: int,
-                 pc_models: List[CalibratedClassifierCV],
+                 pc_models: list[CalibratedClassifierCV],
                  feature_loc: DataLocation,
                  clf_type: str) \
-            -> Tuple[CalibratedClassifierCV,
+            -> tuple[CalibratedClassifierCV,
                      ValResults,
                      TrainClassifierReturnMsg]:
         pass

--- a/spacer/train_utils.py
+++ b/spacer/train_utils.py
@@ -2,6 +2,7 @@
 Utility methods for training classifiers.
 """
 
+from __future__ import annotations
 import logging
 import random
 import string

--- a/spacer/train_utils.py
+++ b/spacer/train_utils.py
@@ -5,7 +5,6 @@ Utility methods for training classifiers.
 import logging
 import random
 import string
-from typing import Tuple, List
 
 import numpy as np
 from sklearn.calibration import CalibratedClassifierCV
@@ -21,7 +20,7 @@ from spacer.messages import DataLocation
 def train(labels: ImageLabels,
           feature_loc: DataLocation,
           nbr_epochs: int,
-          clf_type: str) -> Tuple[CalibratedClassifierCV, List[float]]:
+          clf_type: str) -> tuple[CalibratedClassifierCV, list[float]]:
 
     if len(labels) < config.MIN_TRAINIMAGES:
         raise ValueError('Not enough training samples.')
@@ -91,8 +90,8 @@ def train(labels: ImageLabels,
 
 def evaluate_classifier(clf: CalibratedClassifierCV,
                         labels: ImageLabels,
-                        classes: List[int],
-                        feature_loc: DataLocation) -> Tuple[List, List, List]:
+                        classes: list[int],
+                        feature_loc: DataLocation) -> tuple[list, list, list]:
     """ Evaluates classifier on data """
     scores, gts, ests = [], [], []
     for imkey in labels.image_keys:
@@ -108,13 +107,13 @@ def evaluate_classifier(clf: CalibratedClassifierCV,
     return gts, ests, scores
 
 
-def chunkify(lst: List,
-             nbr_chunks: int) -> List:
+def chunkify(lst: list,
+             nbr_chunks: int) -> list:
     return [lst[i::nbr_chunks] for i in range(nbr_chunks)]
 
 
 def calc_batch_size(max_imgs_in_memory: int,
-                    train_set_size: int) -> Tuple[int, int]:
+                    train_set_size: int) -> tuple[int, int]:
     images_per_batch = min(max_imgs_in_memory, train_set_size)
     batches_per_epoch = int(np.ceil(train_set_size / images_per_batch))
     return images_per_batch, batches_per_epoch
@@ -122,15 +121,17 @@ def calc_batch_size(max_imgs_in_memory: int,
 
 def load_image_data(labels: ImageLabels,
                     imkey: str,
-                    classes: List[int],
+                    classes: list[int],
                     feature_loc: DataLocation) \
-        -> Tuple[List[List[float]], List[int]]:
+        -> tuple[list[list[float]], list[int]]:
     """
-    Loads features and labels for image and matches feature with labels.
+    Loads features and labels for the specified image,
+    and builds element-matching lists for use with methods such as
+    CalibratedClassifierCV.fit().
     """
 
     # Load features for this image.
-    feature_loc.key = imkey  # Set the relevant key here.
+    feature_loc.key = imkey
     image_features = ImageFeatures.load(feature_loc)
 
     # Load row, col, labels for this image.
@@ -183,11 +184,14 @@ def load_image_data(labels: ImageLabels,
 
 
 def load_batch_data(labels: ImageLabels,
-                    imkeylist: List[str],
-                    classes: List[int],
+                    imkeylist: list[str],
+                    classes: list[int],
                     feature_loc: DataLocation) \
-        -> Tuple[List[List[float]], List[int]]:
-    """ Loads features and labels and match them together. """
+        -> tuple[list[list[float]], list[int]]:
+    """
+    Builds element-matching lists of features and labels
+    for multiple images.
+    """
     x, y = [], []
     for imkey in imkeylist:
         x_, y_ = load_image_data(labels, imkey, classes, feature_loc)
@@ -196,7 +200,7 @@ def load_batch_data(labels: ImageLabels,
     return x, y
 
 
-def calc_acc(gt: List[int], est: List[int]) -> float:
+def calc_acc(gt: list[int], est: list[int]) -> float:
     """
     Calculate the accuracy of (agreement between) two integer valued list.
     """
@@ -218,7 +222,7 @@ def calc_acc(gt: List[int], est: List[int]) -> float:
 
 
 def make_random_data(im_count: int,
-                     class_list: List[int],
+                     class_list: list[int],
                      points_per_image: int,
                      feature_dim: int,
                      feature_loc: DataLocation) -> ImageLabels:


### PR DESCRIPTION
Mostly [PEP 585](https://peps.python.org/pep-0585/) and [PEP 604](https://peps.python.org/pep-0604/). I keep wanting to do this every time I edit a file, so might as well get it all out of the way before working on other stuff.

Replacing `Optional[x]` with `x | None` is a little picky, but all else being equal, I think it's better to have one less import. (The `from __future__ import annotations` imports should no longer be necessary whenever pyspacer's minimum version is bumped far enough; I believe it's 3.9 for PEP 585, 3.10 for PEP 604.)