### PR TITLE
Logging: Use getLogger() + provide optional logging config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.7.0 (WIP)
 
+- Added `LOG_DESTINATION` and `LOG_LEVEL` config vars, providing configurable logging for test-suite runs or quick scripts.
+
+- Logging statements throughout pyspacer's codebase now use module-name loggers rather than the root logger, allowing end-applications to keep their logs organized.
+
 - Replaced all SpacerInputErrors and some AssertionErrors with more descriptive error classes.
 
 ## 0.6.1

--- a/README.md
+++ b/README.md
@@ -311,7 +311,15 @@ for row, col, scores in return_message.scores:
 ```
 
 
-## Code coverage
+## Unit tests
+
+Run the test suite by running `python -m unittest` from the `spacer` directory.
+
+- Expect many tests to be skipped, since most test fixtures aren't set up for public access yet.
+
+- Run just a single test module with a command like `python -m unittest tests.test_tasks`, or just `python -m tests.test_tasks` (the latter invokes the `if __name__ == '__main__':` part of the module).
+
+- You can get logging output during test runs with the `LOG_DESTINATION` and `LOG_LEVEL` vars in config.py.
 
 If you are using the docker build or local install, 
 you can check code coverage like so:

--- a/scripts/aws/batch_simple.py
+++ b/scripts/aws/batch_simple.py
@@ -3,11 +3,11 @@ This script submits 10 jobs to queues and monitors as the
 jobs are completed.
 """
 from __future__ import annotations
-import logging
+from logging import getLogger
 
 from scripts.aws.utils import submit_jobs, monitor_jobs
 
-logger = logging.getLogger(__name__)
+logger = getLogger()
 
 
 def main(nbr_rowcols: list[int],

--- a/scripts/aws/batch_simple.py
+++ b/scripts/aws/batch_simple.py
@@ -7,6 +7,8 @@ import logging
 
 from scripts.aws.utils import submit_jobs, monitor_jobs
 
+logger = logging.getLogger(__name__)
+
 
 def main(nbr_rowcols: list[int],
          job_queue: str = 'shakeout',
@@ -14,7 +16,7 @@ def main(nbr_rowcols: list[int],
 
     targets = []
     for name in ['efficientnet_b0_ver1', 'vgg16_coralnet_ver1']:
-        logging.info("Starting scaling test for {}.".format(name))
+        logger.info("Starting scaling test for {}.".format(name))
         targets.extend(submit_jobs(nbr_rowcols, job_queue, image_size, name))
 
     _, runtime = monitor_jobs(targets)

--- a/scripts/aws/utils.py
+++ b/scripts/aws/utils.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 import json
-import logging
 import time
 from collections import defaultdict
 from datetime import datetime
+from logging import getLogger
 
 import boto3
 import numpy as np
@@ -14,7 +14,7 @@ from spacer.messages import ExtractFeaturesMsg, DataLocation, JobMsg
 from spacer.messages import JobReturnMsg
 from spacer.storage import store_image, load_image
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def aws_batch_submit(job_queue: str,

--- a/scripts/regression/retrain_source.py
+++ b/scripts/regression/retrain_source.py
@@ -7,10 +7,10 @@ This file provides scripts for
 
 import json
 import os
+import warnings
+from logging import basicConfig
 
 import fire
-import logging
-import warnings
 
 from spacer import config
 from scripts.regression.utils import build_traindata, do_training, \
@@ -42,9 +42,9 @@ def train(source_id: int,
     if not os.path.exists(image_root):
         os.makedirs(image_root)
 
-    logging.basicConfig(format='%(asctime)s %(message)s',
-                        filename=os.path.join(source_root, 'retrain.log'),
-                        level=logging.INFO)
+    basicConfig(format='%(asctime)s %(message)s',
+                filename=os.path.join(source_root, 'retrain.log'),
+                level='INFO')
 
     # Download all data to local.
     if extractor_name is None:

--- a/spacer/config.py
+++ b/spacer/config.py
@@ -173,10 +173,10 @@ class log_entry_and_exit(ContextDecorator):
 
     def __enter__(self):
         self.start_time = time.time()
-        logger.info('Entering: %s', self.name)
+        logger.debug('Entering: %s', self.name)
 
     def __exit__(self, exc_type, exc, exc_tb):
-        logger.info('Exiting: %s after %f seconds.', self.name,
+        logger.debug('Exiting: %s after %f seconds.', self.name,
                      time.time() - self.start_time)
 
 

--- a/spacer/config.py
+++ b/spacer/config.py
@@ -5,12 +5,12 @@ Contains config and settings for the repo.
 from __future__ import annotations
 import importlib
 import json
-import logging
 import os
 import sys
 import time
 import warnings
 from contextlib import ContextDecorator
+from logging import basicConfig, getLogger
 from pathlib import Path
 from typing import Any
 
@@ -19,7 +19,7 @@ from PIL import Image, ImageFile
 
 from spacer.exceptions import ConfigError
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def filter_warnings():
@@ -135,7 +135,7 @@ def get_config_value(key: str, default: Any = 'NO_DEFAULT') -> Any:
 LOG_DESTINATION = get_config_value('LOG_DESTINATION', default=None)
 # And this is the log level to use when logging to that destination.
 # Specify as "INFO", etc.
-LOG_LEVEL = get_config_value('LOG_LEVEL', default=logging.INFO)
+LOG_LEVEL = get_config_value('LOG_LEVEL', default='INFO')
 
 if LOG_DESTINATION:
     if LOG_DESTINATION == 'console':
@@ -143,7 +143,7 @@ if LOG_DESTINATION:
     else:
         filename = LOG_DESTINATION
 
-    logging.basicConfig(
+    basicConfig(
         level=LOG_LEVEL,
         filename=filename,
         format='%(asctime)s - %(levelname)s:%(name)s\n%(message)s',

--- a/spacer/config.py
+++ b/spacer/config.py
@@ -128,6 +128,28 @@ def get_config_value(key: str, default: Any = 'NO_DEFAULT') -> Any:
     return handle_unspecified_setting()
 
 
+# If your end application/script doesn't configure its own logging,
+# or if you're running unit tests and want log output, you can specify this
+# config value to output logs to console or to a file of your choice.
+# Specify either as 'console', or as an absolute path to the desired file.
+LOG_DESTINATION = get_config_value('LOG_DESTINATION', default=None)
+# And this is the log level to use when logging to that destination.
+# Specify as "INFO", etc.
+LOG_LEVEL = get_config_value('LOG_LEVEL', default=logging.INFO)
+
+if LOG_DESTINATION:
+    if LOG_DESTINATION == 'console':
+        filename = None
+    else:
+        filename = LOG_DESTINATION
+
+    logging.basicConfig(
+        level=LOG_LEVEL,
+        filename=filename,
+        format='%(asctime)s - %(levelname)s:%(name)s\n%(message)s',
+    )
+
+
 def get_s3_conn():
     """
     Returns a boto s3 connection.
@@ -239,6 +261,8 @@ CONFIGURABLE_VARS = [
     'TEST_EXTRACTORS_BUCKET',
     'TEST_BUCKET',
     # These can just be configured as needed, or left as defaults.
+    'LOG_DESTINATION',
+    'LOG_LEVEL',
     'MAX_IMAGE_PIXELS',
     'MAX_POINTS_PER_IMAGE',
     'MIN_TRAINIMAGES',

--- a/spacer/config.py
+++ b/spacer/config.py
@@ -19,6 +19,8 @@ from PIL import Image, ImageFile
 
 from spacer.exceptions import ConfigError
 
+logger = logging.getLogger(__name__)
+
 
 def filter_warnings():
     """ Filters out some verified warnings. """
@@ -149,10 +151,10 @@ class log_entry_and_exit(ContextDecorator):
 
     def __enter__(self):
         self.start_time = time.time()
-        logging.info('Entering: %s', self.name)
+        logger.info('Entering: %s', self.name)
 
     def __exit__(self, exc_type, exc, exc_tb):
-        logging.info('Exiting: %s after %f seconds.', self.name,
+        logger.info('Exiting: %s after %f seconds.', self.name,
                      time.time() - self.start_time)
 
 

--- a/spacer/mailman.py
+++ b/spacer/mailman.py
@@ -5,6 +5,7 @@ Defines the highest-level method for task handling through AWS Batch.
 import json
 import logging
 import os
+from logging.config import dictConfig
 
 import fire
 
@@ -70,7 +71,7 @@ def env_job(): # pragma: no cover
 
 if __name__ == '__main__':
 
-    logging.config.dictConfig({
+    dictConfig({
         'version': 1,
         'formatters': {
             'spacer': {

--- a/spacer/mailman.py
+++ b/spacer/mailman.py
@@ -3,8 +3,8 @@ Defines the highest-level method for task handling through AWS Batch.
 """
 
 import json
-import logging
 import os
+from logging import getLogger
 from logging.config import dictConfig
 
 import fire
@@ -13,7 +13,8 @@ from spacer import config
 from spacer.messages import JobMsg, DataLocation
 from spacer.tasks import process_job
 
-logger = logging.getLogger(__name__)
+# Root logger. Logging options seem otherwise limited for __main__.
+logger = getLogger()
 
 
 def env_job(): # pragma: no cover
@@ -33,7 +34,7 @@ def env_job(): # pragma: no cover
         raise ValueError('JOB_MSG_LOC env. variable not set. '
                          'Can not process job.')
 
-    logger.info(" Received job for ENV {}.".format(job_msg_loc))
+    logger.info(f"Received job from env var: {job_msg_loc}")
 
     with config.log_entry_and_exit('job message location deserialization'):
         job_msg_loc = DataLocation.deserialize(json.loads(job_msg_loc))

--- a/spacer/mailman.py
+++ b/spacer/mailman.py
@@ -12,6 +12,8 @@ from spacer import config
 from spacer.messages import JobMsg, DataLocation
 from spacer.tasks import process_job
 
+logger = logging.getLogger(__name__)
+
 
 # Configure a simple logger that works with AWS CloudWatch.
 if len(logging.getLogger().handlers) > 0:
@@ -40,7 +42,7 @@ def env_job(): # pragma: no cover
         raise ValueError('JOB_MSG_LOC env. variable not set. '
                          'Can not process job.')
 
-    logging.info(" Received job for ENV {}.".format(job_msg_loc))
+    logger.info(" Received job for ENV {}.".format(job_msg_loc))
 
     with config.log_entry_and_exit('job message location deserialization'):
         job_msg_loc = DataLocation.deserialize(json.loads(job_msg_loc))

--- a/spacer/tasks.py
+++ b/spacer/tasks.py
@@ -19,6 +19,8 @@ from spacer.storage import load_image, load_classifier, store_classifier
 from spacer.task_utils import check_extract_inputs
 from spacer.train_classifier import trainer_factory
 
+logger = logging.getLogger(__name__)
+
 
 def extract_features(msg: ExtractFeaturesMsg) -> ExtractFeaturesReturnMsg:
 
@@ -119,7 +121,7 @@ def process_job(job_msg: JobMsg) -> JobReturnMsg:
                     job_msg.task_name, task.job_token)):
                 results.append(run[job_msg.task_name](task))
         except Exception:
-            logging.error('Error executing job {}: {}'.format(
+            logger.error('Error executing job {}: {}'.format(
                 task.job_token, traceback.format_exc()))
             return_msg = JobReturnMsg(
                 original_job=job_msg,

--- a/spacer/tasks.py
+++ b/spacer/tasks.py
@@ -1,9 +1,9 @@
 """
 Defines the highest level methods for completing tasks.
 """
-import logging
 import time
 import traceback
+from logging import getLogger
 
 from spacer import config
 from spacer.data_classes import ImageFeatures
@@ -19,7 +19,7 @@ from spacer.storage import load_image, load_classifier, store_classifier
 from spacer.task_utils import check_extract_inputs
 from spacer.train_classifier import trainer_factory
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def extract_features(msg: ExtractFeaturesMsg) -> ExtractFeaturesReturnMsg:

--- a/spacer/train_utils.py
+++ b/spacer/train_utils.py
@@ -3,9 +3,9 @@ Utility methods for training classifiers.
 """
 
 from __future__ import annotations
-import logging
 import random
 import string
+from logging import getLogger
 
 import numpy as np
 from sklearn.calibration import CalibratedClassifierCV
@@ -17,7 +17,7 @@ from spacer.data_classes import ImageLabels, ImageFeatures
 from spacer.exceptions import RowColumnMismatchError
 from spacer.messages import DataLocation
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def train(labels: ImageLabels,

--- a/spacer/train_utils.py
+++ b/spacer/train_utils.py
@@ -41,13 +41,13 @@ def train(labels: ImageLabels,
     np.random.shuffle(ref_set)
     ref_set = ref_set[:max_imgs_in_memory]  # Enforce memory limit.
     train_set = list(set(labels.image_keys) - set(ref_set))
-    logger.info("Trainset: {}, valset: {} images".
+    logger.debug("Trainset: {}, valset: {} images".
                  format(len(train_set), len(ref_set)))
 
     # Figure out # images per batch and batches per epoch.
     images_per_batch, batches_per_epoch = \
         calc_batch_size(max_imgs_in_memory, len(train_set))
-    logger.info("Using {} images per mini-batch and {} mini-batches per "
+    logger.debug("Using {} images per mini-batch and {} mini-batches per "
                  "epoch".format(images_per_batch, batches_per_epoch))
 
     # Identify classes common to both train and val.
@@ -55,7 +55,7 @@ def train(labels: ImageLabels,
     trainclasses = labels.unique_classes(train_set)
     refclasses = labels.unique_classes(ref_set)
     classes = list(trainclasses.intersection(refclasses))
-    logger.info("Trainset: {}, valset: {}, common: {} labels".format(
+    logger.debug("Trainset: {}, valset: {}, common: {} labels".format(
         len(trainclasses), len(refclasses), len(classes)))
     if len(classes) == 1:
         raise ValueError('Not enough classes to do training (only 1)')
@@ -82,7 +82,7 @@ def train(labels: ImageLabels,
                 x, y = load_batch_data(labels, mb, classes, feature_loc)
                 clf.partial_fit(x, y, classes=classes)
             ref_acc.append(calc_acc(refy, clf.predict(refx)))
-            logger.info("Epoch {}, acc: {}".format(epoch, ref_acc[-1]))
+            logger.debug("Epoch {}, acc: {}".format(epoch, ref_acc[-1]))
 
     with config.log_entry_and_exit("calibration"):
         clf_calibrated = CalibratedClassifierCV(clf, cv="prefit")


### PR DESCRIPTION
I finally learned why there was so much logging output when running pyspacer tests or coralnet tests.

pyspacer was logging using the form `logging.info(...)`. Generally the better practice is to instead do `logger = logging.getLogger(__name__)` followed by `logger.info(...)`. Two reasons why it's a better practice:

1. logging.info() logs to the root logger, while the latter method uses Python's module-name hierarchy of loggers, which allows end-applications to capture log statements from different sources in different ways.

2. From the docs about logging.debug(), logging.info(), etc.: [https://docs.python.org/3/library/logging.html#logging.debug](link):

   > This function (as well as `info()`, `warning()`, `error()` and `critical()`) will call `basicConfig()` if the root logger doesn’t have any handler attached.

   In our case, as soon as the first `logging.info(...)` statement was reached, absolutely every log statement thereafter would log to console output, regardless of how logging had been configured before. This was particularly jarring with coralnet's unit tests: the console output would just have the pass/fail indicators until maybe halfway through, then a `logging.info(...)` would get reached and the console would fill up with other stuff.

This PR would:

- Change all of pyspacer's logging statements to the `getLogger` pattern.

- Demote some logging statements (mostly profiling training) from INFO to DEBUG, and change mailman.py logging config so that it still captures those statements. (Recently there's a question of whether mailman.py should be moved to a coralnet-internal repo, but that's to be resolved another day.)

- Provide an optional logging configuration that can be used by specifying the new `LOG_DESTINATION` and `LOG_LEVEL` spacer config vars.

  ```python
  # If your end application/script doesn't configure its own logging,
  # or if you're running unit tests and want log output, you can specify this
  # config value to output logs to console or to a file of your choice.
  # Specify either as 'console', or as an absolute path to the desired file.
  LOG_DESTINATION = get_config_value('LOG_DESTINATION', default=None)
  # And this is the log level to use when logging to that destination.
  # Specify as "INFO", etc.
  LOG_LEVEL = get_config_value('LOG_LEVEL', default='INFO')
  ```

  This can be useful for getting logs during unit-test runs, and I added a line to the README to point this out. It does feel a little odd that pyspacer "has to" provide a logging config in this manner, but I couldn't think of a better way to make the pyspacer test suite conveniently (and optionally) runnable with log output. There's a chance I'm missing something, but not the biggest-priority issue and can be future work.
