### PR TITLE
Training: cache feature vectors for 2nd epoch onward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - The `train_classifier` task now accepts label IDs as either integers or strings, not just integers.
 
+- The `train_classifier` task is now able to locally cache feature vectors which were loaded from remote storage, which can greatly speed up training from epoch 2 onward. This is optional and enabled by default; the location of the cache directory is also configurable.
+
 ## 0.8.0
 
 - `ImageFeatures` with `valid_rowcol=False` are no longer supported for training. For now they are still supported for classification.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,19 @@ message = TrainClassifierMsg(
     model_loc=DataLocation('filesystem', '/path/to/classifier1.pkl'),
     # Where the detailed evaluation results of the new model should be stored.
     valresult_loc=DataLocation('filesystem', '/path/to/valresult.json'),
+    # If feature vectors are loaded from remote storage, this specifies
+    # where the feature-vector cache (a temporary directory in the local
+    # filesystem) is located. Can be:
+    # - The special value FeatureCache.AUTO, which lets the OS decide where
+    #   the temporary directory lives. (Default)
+    # - The special value FeatureCache.DISABLED, which makes feature
+    #   vectors get loaded remotely every time without being cached
+    #   (which means most vectors will be remote-loaded once per epoch).
+    #   This would be desired if there isn't enough disk space to cache all
+    #   features.
+    # - Absolute path to the directory where the cache will live, either
+    #   as a str or a pathlib.Path.
+    feature_cache_dir=TrainClassifierMsg.FeatureCache.AUTO,
 )
 return_message = train_classifier(message)
 print("Classifier stored at: /path/to/classifier1.pkl")

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -13,7 +13,7 @@ from typing import TypeAlias
 
 import numpy as np
 
-from spacer.storage import storage_factory
+from spacer.storage import RemoteStorage, storage_factory
 
 
 # LabelId is constrained by scikit-learn's usage of 'targets':
@@ -280,9 +280,12 @@ class ImageFeatures(DataClass):
 
     @classmethod
     def load(cls, loc: 'DataLocation'):
-
         storage = storage_factory(loc.storage_type, loc.bucket_name)
-        stream = storage.load(loc.key)
+        # TODO: This is extremely ugly OOP
+        if isinstance(storage, RemoteStorage):
+            stream = storage.load(loc.key, loc.filesystem_cache)
+        else:
+            stream = storage.load(loc.key)
         stream.seek(0)
         try:
             data = np.load(stream)

--- a/spacer/messages.py
+++ b/spacer/messages.py
@@ -31,6 +31,8 @@ class DataLocation(DataClass):
         self.key = key
         self.bucket_name = bucket_name
 
+        self.filesystem_cache = None
+
     @classmethod
     def example(cls) -> 'DataLocation':
         return DataLocation('memory', 'my_blob')
@@ -52,9 +54,22 @@ class DataLocation(DataClass):
     def is_writable(self) -> bool:
         return self.storage_type != 'url'
 
+    def set_filesystem_cache(self, dir_path):
+        if not self.is_remote:
+            raise TypeError(
+                "Filesystem caching is only available for remote storage.")
+        self.filesystem_cache = dir_path
+
     @classmethod
     def deserialize(cls, data: dict) -> 'DataLocation':
         return DataLocation(**data)
+
+    def serialize(self) -> dict:
+        return dict(
+            storage_type=self.storage_type,
+            key=self.key,
+            bucket_name=self.bucket_name,
+        )
 
     def __hash__(self):
         return hash((self.storage_type, self.key, self.bucket_name))

--- a/spacer/messages.py
+++ b/spacer/messages.py
@@ -267,13 +267,13 @@ class TrainClassifierMsg(DataClass):
         # stored.
         valresult_loc: DataLocation,
         # If feature vectors are loaded from remote storage, this specifies
-        # where the feature-vector cache (a temporary directory in the
+        # where the feature-vector cache (a temporary directory in the local
         # filesystem) is located. Can be:
         # - The special value FeatureCache.AUTO, which lets the OS decide where
-        #   the temporary directory lives.
-        # - The special value FeatureCache.DISABLED, to not cache feature
-        #   vectors, which means vectors are loaded in remotely on every epoch,
-        #   not just the first epoch.
+        #   the temporary directory lives. (Default)
+        # - The special value FeatureCache.DISABLED, which makes feature
+        #   vectors get loaded remotely every time without being cached
+        #   (which means most vectors will be remote-loaded once per epoch).
         #   This would be desired if there isn't enough disk space to cache all
         #   features.
         # - Absolute path to the directory where the cache will live, either

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -21,17 +21,20 @@ from spacer.messages import (
     TrainClassifierReturnMsg,
     TrainingTaskLabels,
 )
-from spacer.storage import \
-    store_classifier, \
-    load_classifier, \
-    clear_memory_storage, \
-    store_image, \
-    storage_factory
-from spacer.tasks import \
-    extract_features, \
-    train_classifier, \
-    classify_features, \
-    classify_image
+from spacer.storage import (
+    clear_memory_storage,
+    load_classifier,
+    S3Storage,
+    storage_factory,
+    store_classifier,
+    store_image,
+)
+from spacer.tasks import (
+    classify_features,
+    classify_image,
+    extract_features,
+    train_classifier,
+)
 from spacer.task_utils import preprocess_labels
 from spacer.tests.utils import cn_beta_fixture_location
 from spacer.train_utils import make_random_data, train
@@ -157,6 +160,20 @@ class TestExtractFeatures(unittest.TestCase):
         _ = extract_features(msg)
         features = ImageFeatures.load(msg.feature_loc)
         self.assertEqual(len(features.point_features), len(msg.rowcols))
+
+
+def spy_decorator(method_to_decorate):
+    """
+    A way to track calls to a class's instance method, across all instances
+    of the class. From:
+    https://stackoverflow.com/a/41599695
+    """
+    mock_obj = mock.MagicMock()
+    def wrapper(self, *args, **kwargs):
+        mock_obj(*args, **kwargs)
+        return method_to_decorate(self, *args, **kwargs)
+    wrapper.mock_obj = mock_obj
+    return wrapper
 
 
 class TestTrainClassifier(unittest.TestCase):
@@ -288,8 +305,8 @@ class TestTrainClassifier(unittest.TestCase):
         with self.assertRaises(RowColumnMismatchError):
             train_classifier(msg)
 
-    @require_test_fixtures
-    def test_feature_caching(self):
+    @staticmethod
+    def do_feature_caching_test(feature_cache_dir):
         n_data = 3
         points_per_image = 10
         feature_dim = 5
@@ -312,17 +329,31 @@ class TestTrainClassifier(unittest.TestCase):
             previous_model_locs=[],
             model_loc=DataLocation(storage_type='memory', key='model'),
             valresult_loc=DataLocation(storage_type='memory', key='valresult'),
+            feature_cache_dir=feature_cache_dir,
         )
 
-        # TODO: This breaks _load_remote(). How to not break it while still being able to track the call count?
-        # with mock.patch(
-        #         'spacer.storage.S3Storage._load_remote') as mock_method:
-        #     train_classifier(msg)
-        # self.assertEqual(
-        #     mock_method.call_count, 3,
-        #     "Should go like: download ref, download train, cache load"
-        #     " train, download val")
-        train_classifier(msg)
+        load_remote = spy_decorator(S3Storage._load_remote)
+        with mock.patch.object(S3Storage, '_load_remote', load_remote):
+            train_classifier(msg)
+        return load_remote.mock_obj
+
+    @require_test_fixtures
+    def test_feature_caching_enabled(self):
+        load_remote_mock = self.do_feature_caching_test(
+            TrainClassifierMsg.FeatureCache.AUTO)
+        self.assertEqual(
+            load_remote_mock.call_count, 3,
+            "Should go like: download ref, download train, cache-load"
+            " train, download val")
+
+    @require_test_fixtures
+    def test_feature_caching_disabled(self):
+        load_remote_mock = self.do_feature_caching_test(
+            TrainClassifierMsg.FeatureCache.DISABLED)
+        self.assertEqual(
+            load_remote_mock.call_count, 4,
+            "Should go like: download ref, download train, download"
+            " train, download val")
 
 
 class ClassifyReturnMsgTest(unittest.TestCase):

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -1,5 +1,6 @@
 import random
 import unittest
+from unittest import mock
 
 from PIL import Image
 
@@ -286,6 +287,42 @@ class TestTrainClassifier(unittest.TestCase):
 
         with self.assertRaises(RowColumnMismatchError):
             train_classifier(msg)
+
+    @require_test_fixtures
+    def test_feature_caching(self):
+        n_data = 3
+        points_per_image = 10
+        feature_dim = 5
+        class_list = [1, 2]
+
+        # Remote storage.
+        features_loc_template = DataLocation(
+            storage_type='s3', key='', bucket_name=config.TEST_BUCKET)
+
+        msg = TrainClassifierMsg(
+            job_token='test',
+            trainer_name='minibatch',
+            nbr_epochs=2,
+            clf_type='MLP',
+            labels=preprocess_labels(make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            )),
+            features_loc=features_loc_template,
+            previous_model_locs=[],
+            model_loc=DataLocation(storage_type='memory', key='model'),
+            valresult_loc=DataLocation(storage_type='memory', key='valresult'),
+        )
+
+        # TODO: This breaks _load_remote(). How to not break it while still being able to track the call count?
+        # with mock.patch(
+        #         'spacer.storage.S3Storage._load_remote') as mock_method:
+        #     train_classifier(msg)
+        # self.assertEqual(
+        #     mock_method.call_count, 3,
+        #     "Should go like: download ref, download train, cache load"
+        #     " train, download val")
+        train_classifier(msg)
 
 
 class ClassifyReturnMsgTest(unittest.TestCase):


### PR DESCRIPTION
Cache feature vectors in the local filesystem if they were loaded from remote storage (S3 or URL).

I *think* this will do what it intends to, but I couldn't figure out a way to do it without committing OOP crimes somewhere (`data_classes.ImageFeatures.load()` in this case). I think the better way to do this would involve passing a `Storage` to TrainClassifierMsg instead of a `DataLocation`, and putting the temporary directory attribute onto that Storage. That probably involves a much larger refactor overall where the designs of `Storage`, `DataLocation`, and perhaps `DataClass` are reworked. I have ideas for that but I don't think I'm up for that for the remainder of the month.

Also want to make the caching optional (but on by default), so that it can be turned off in case filesystem space is a concern, as it may be for coralnet's largest sources (particularly since older sources have feature vectors about 8x in filesize).

Let me know if it'd be useful to merge this PR in the short term though.