### PR TITLE
Don't accept no-rowcol features for training anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0 (WIP)
+
+- `ImageFeatures` with `valid_rowcol=False` are no longer supported for training. For now they are still supported for classification.
+
 ## 0.7.0
 
 - `TrainClassifierMsg` labels arguments have changed. Instead of `train_labels` and `val_labels`, it now takes a single argument `labels`, which is a `TrainingTaskLabels` object (basically a set of 3 `ImageLabels` objects: training set, reference set, and validation set).


### PR DESCRIPTION
We can still support legacy features for classification, but for training it's getting to be a software-engineering pain, because it doesn't play nice with the filtering done in preprocess_labels(). Details in issue #82.