### PR TITLE
S3 downloads are now always performed in the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - `ImageFeatures` with `valid_rowcol=False` are no longer supported for training. For now they are still supported for classification.
 
+- S3 downloads are now always performed in the main thread, to prevent `RuntimeError: cannot schedule new futures after interpreter shutdown`.
+
 ## 0.7.0
 
 - `TrainClassifierMsg` labels arguments have changed. Instead of `train_labels` and `val_labels`, it now takes a single argument `labels`, which is a `TrainingTaskLabels` object (basically a set of 3 `ImageLabels` objects: training set, reference set, and validation set).


### PR DESCRIPTION
This is to prevent `RuntimeError: cannot schedule new futures after interpreter shutdown`, similar to https://github.com/coralnet/coralnet/pull/527. The error was happening at this part of pyspacer's code when the `backend_main` view tried to get the valresults of a classifier.

This should only affect performance if a pyspacer-dependent program were trying to parallelize S3 downloads using multithreading. Multiprocessing should be unaffected.