### PR TITLE
Fix bucket_name bucketname consistency

### DIFF
--- a/spacer/tasks.py
+++ b/spacer/tasks.py
@@ -3,6 +3,7 @@ Defines the highest level methods for completing tasks.
 """
 import time
 import traceback
+from logging import getLogger
 from typing import Callable
 from spacer import config
 from spacer.data_classes import ImageFeatures
@@ -24,17 +25,9 @@ logger = getLogger(__name__)
 def extract_features(msg: ExtractFeaturesMsg) -> ExtractFeaturesReturnMsg:
 
     img = load_image(msg.image_loc)
-
-    check_extract_inputs(img, msg.rowcols, msg.image_loc.key)
-
-    check_rowcols(msg.rowcols, img)
-    if not isinstance(msg.extractor, Callable):
-        raise TypeError("msg.extractor must be callable")
-    
+    check_extract_inputs(img, msg.rowcols, msg.image_loc.key)   
     with config.log_entry_and_exit('actual extraction'):
         features, return_msg = msg.extractor(img, msg.rowcols)
-    if not hasattr(features, 'store'):
-        raise TypeError("features object must have a store method")
 
     with config.log_entry_and_exit('storing features'):
         features.store(msg.feature_loc)

--- a/spacer/tasks.py
+++ b/spacer/tasks.py
@@ -3,8 +3,7 @@ Defines the highest level methods for completing tasks.
 """
 import time
 import traceback
-from logging import getLogger
-
+from typing import Callable
 from spacer import config
 from spacer.data_classes import ImageFeatures
 from spacer.messages import \
@@ -28,8 +27,14 @@ def extract_features(msg: ExtractFeaturesMsg) -> ExtractFeaturesReturnMsg:
 
     check_extract_inputs(img, msg.rowcols, msg.image_loc.key)
 
+    check_rowcols(msg.rowcols, img)
+    if not isinstance(msg.extractor, Callable):
+        raise TypeError("msg.extractor must be callable")
+    
     with config.log_entry_and_exit('actual extraction'):
         features, return_msg = msg.extractor(img, msg.rowcols)
+    if not hasattr(features, 'store'):
+        raise TypeError("features object must have a store method")
 
     with config.log_entry_and_exit('storing features'):
         features.store(msg.feature_loc)


### PR DESCRIPTION
Separating out into smaller PRs  :smile_cat: 

Refactor for consistency see: https://github.com/coralnet/pyspacer/blob/cb0b427b03f60bb92e2e9bdf1ccbb64e5b2230c3/spacer/storage.py#L187

https://github.com/coralnet/pyspacer/blob/cb0b427b03f60bb92e2e9bdf1ccbb64e5b2230c3/spacer/storage.py#L205

https://github.com/coralnet/pyspacer/blob/cb0b427b03f60bb92e2e9bdf1ccbb64e5b2230c3/spacer/messages.py#L25





