### PR TITLE
Add timeout to URLStorage's urlopen() usages

### DIFF
--- a/spacer/storage.py
+++ b/spacer/storage.py
@@ -68,11 +68,15 @@ class URLStorage(Storage):
                 url, timeout=self.TIMEOUT)
         except (socket.timeout, URLError, ValueError) as e:
             # Besides timeouts, possible errors include:
-            # ValueError - unknown url type: '<url>'
+            # ValueError: unknown url type: '<url>'
             #   - Malformed url
-            # URLError - <urlopen error [Errno -5] No address associated with
-            # hostname> [Linux] OR gaierror(11001, 'getaddrinfo failed') [Win]
+            # URLError: <urlopen error [Errno -5] No address associated with
+            # hostname> [Linux]
+            # OR gaierror(11001, 'getaddrinfo failed') [Win]
             #   - Invalid domain
+            # URLError: <urlopen error [Errno -3] Temporary failure in name
+            # resolution>
+            #   - No internet
             # HTTPError 404 or 500
             #   - HTTPError inherits from URLError
             raise URLDownloadError(

--- a/spacer/storage.py
+++ b/spacer/storage.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import abc
 import os
 import pickle
+import socket
 import warnings
 from functools import lru_cache
 from http.client import IncompleteRead
@@ -46,6 +47,8 @@ class Storage(abc.ABC):  # pragma: no cover
 class URLStorage(Storage):
     """ Loads items from URLs. Does not support store operations. """
 
+    TIMEOUT = 20.0
+
     def __init__(self):
         self.fs_storage = FileSystemStorage()
 
@@ -54,12 +57,21 @@ class URLStorage(Storage):
 
     def load(self, url: str) -> BytesIO:
         try:
-            download_response = urllib.request.urlopen(url)
-        except (URLError, ValueError) as e:
-            # Possible errors include:
+            # The timeout here defines the max time for both:
+            # - The initial connection; else URLError - <urlopen error timed
+            #   out> is raised.
+            # - A single idle period mid-response (not the entire response
+            #   time); else socket.timeout - timed out is raised
+            #   (socket.timeout is a deprecated alias of TimeoutError starting
+            #   in Python 3.10).
+            download_response = urllib.request.urlopen(
+                url, timeout=self.TIMEOUT)
+        except (socket.timeout, URLError, ValueError) as e:
+            # Besides timeouts, possible errors include:
             # ValueError - unknown url type: '<url>'
             #   - Malformed url
-            # URLError - gaierror(11001, 'getaddrinfo failed')
+            # URLError - <urlopen error [Errno -5] No address associated with
+            # hostname> [Linux] OR gaierror(11001, 'getaddrinfo failed') [Win]
             #   - Invalid domain
             # HTTPError 404 or 500
             #   - HTTPError inherits from URLError
@@ -81,6 +93,10 @@ class URLStorage(Storage):
         raise TypeError('Delete operation not supported for URL storage.')
 
     def exists(self, url: str) -> bool:
+        """
+        URL existence can be a hard problem.
+        This implementation makes no guarantees on correctness.
+        """
         # HEAD can check for existence without downloading the entire resource
         try:
             request = urllib.request.Request(url, method='HEAD')
@@ -89,8 +105,9 @@ class URLStorage(Storage):
             return False
 
         try:
-            urllib.request.urlopen(request)
-        except URLError:
+            urllib.request.urlopen(request, timeout=self.TIMEOUT)
+        except (socket.timeout, URLError):
+            # Might be an unreachable domain, 404, or something else
             return False
         return True
 


### PR DESCRIPTION
I noticed that the URLStorage `test_exists()` test would sometimes hang indefinitely on my local machine. Turns out it was happening on `UNREACHABLE_URL`, an undefined coralnet URL which is supposed to return 404. Seems that was happening because `urlopen()`, used in URLStorage's `exists()`, doesn't define a timeout by default. And of course, the coralnet site has been known (especially recently) to be unresponsive for minutes at times.

I don't know whether the deploy-API jobs running on Batch had timeouts or not, but for what it's worth, I haven't seen any `TimeoutError` logged in the past couple of months (i.e. since `urlopen()` replaced `wget` here in production). One would think a lack of timeout there could endanger our Batch resources. I'm not sure what are the chances that could also propagate to endangering the web server's responsiveness; it might.

What I do know is that my local environment seems to benefit from an explicit timeout in URLStorage's `urlopen()` usages, and that it wouldn't hurt to have for production as well. So that's what this PR adds.

I took some time to mess around with Python sockets to confirm the semantics of the timeout kwarg. It seems that it gets a `URLError` if the initial part of the response doesn't arrive by the timeout, and it gets a `socket.timeout` (superseded by and aliased to `TimeoutError` in Python 3.10, which is coralnet's Python version) if there's a continuous idle period surpassing the timeout in the middle of sending the response. It is not a timeout enforced against the entire duration of the response, so if there is just a lot of data to send over a low-bandwidth connection, then that's not a concern.

URLStorage test updates in the meantime:

- Use mocking instead of an `UNREACHABLE_URL`. This way we can test the code paths for a 404 and a timeout without relying on the status/characteristics of a particular live website.
- Also use mocking instead of an `UNREACHABLE_DOMAIN`. If CI doesn't have internet connectivity, then it gets a different error because it can't do a DNS lookup at all.
- Apply `@require_test_fixtures` to fewer tests so that some of these updated tests can be run in CI.