### PR TITLE
Accept int or str as label ID, not just int

### DIFF
--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -86,7 +86,9 @@ class ImageLabels(DataClass):
 
     @property
     def label_count(self):
-        return self.label_count_per_class.total()
+        # In Python 3.10+, this can be
+        # `return self.label_count_per_class.total()`
+        return sum(self.label_count_per_class.values())
 
     @classmethod
     def example(cls):

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -6,6 +6,7 @@ python-native data-structures such that it can be stored.
 from __future__ import annotations
 import json
 from abc import ABC, abstractmethod
+from collections import Counter
 from io import BytesIO
 from pprint import pformat
 
@@ -74,13 +75,18 @@ class ImageLabels(DataClass):
                  data: dict[str, list[tuple[int, int, int]]]):
         self._data = data
 
-        self.label_count = sum([len(labels) for labels in data.values()])
+        self.label_count_per_class = Counter()
+        for single_image_annotations in data.values():
+            labels = [label for (row, col, label) in single_image_annotations]
+            self.label_count_per_class.update(labels)
 
-        self.classes_set = set()
-        for single_image_labels in data.values():
-            single_image_classes = set(
-                label for (row, col, label) in single_image_labels)
-            self.classes_set |= single_image_classes
+    @property
+    def classes_set(self):
+        return set(self.label_count_per_class.keys())
+
+    @property
+    def label_count(self):
+        return self.label_count_per_class.total()
 
     @classmethod
     def example(cls):

--- a/spacer/messages.py
+++ b/spacer/messages.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from spacer import config
-from spacer.data_classes import DataClass, ImageLabels
+from spacer.data_classes import DataClass, ImageLabels, LabelId
 
 
 class DataLocation(DataClass):
@@ -442,7 +442,7 @@ class ClassifyReturnMsg(DataClass):
                  # Scores is a list of (row, col, [scores]) tuples.
                  scores: list[tuple[int, int, list[float]]],
                  # Maps the score index to a global class id.
-                 classes: list[int],
+                 classes: list[LabelId],
                  valid_rowcol: bool):
 
         self.runtime = runtime

--- a/spacer/task_utils.py
+++ b/spacer/task_utils.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+from collections import defaultdict
+from enum import Enum
 from logging import getLogger
 
 from PIL import Image
+from sklearn.model_selection import train_test_split
 
 from spacer import config
 from spacer.data_classes import ImageLabels
@@ -61,17 +64,163 @@ def check_extract_inputs(image: Image,
                 f" valid range of 0-{im_width - 1}.")
 
 
+class ClassSamplingMethod(Enum):
+    """
+    How to consider classes when splitting annotations between
+    train, ref, and val sets.
+    """
+    # Sample with no regard to classes.
+    IGNORE = 'ignore'
+    # Stratified sampling by class: an A%/B%/C% train/ref/val split means
+    # about an A%/B%/C% split of each class.
+    #
+    # Stratification checks that the number of annotations in each
+    # set isn't less than the number of unique classes.
+    # However, each set is NOT guaranteed to have at least 1 of each class.
+    # If stratification is calculated such that a set would get <0.5
+    # annotations of a class, then that set gets 0 of that class.
+    STRATIFIED = 'stratified'
+
+
+def split_labels(
+    labels_in: ImageLabels,
+    # Reference set's max ratio (also capped by
+    # TRAINING_BATCH_LABEL_COUNT) and validation set's ratio.
+    # Remaining annotations go to the training set.
+    # Example: (0.5, 0.15) for a 5% ref / 15% val / 80% train split.
+    split_ratios: tuple[float, float],
+    class_sampling: ClassSamplingMethod,
+) -> TrainingTaskLabels:
+    """
+    Split annotation data into training, reference, and validation sets.
+    """
+
+    # Determine train/ref/val annotation count goals.
+    # Note that these aren't necessarily going to be the final counts for
+    # training.
+    # If class filtering occurs after this function call, then the counts
+    # will change.
+    ref_max_ratio, val_ratio = split_ratios
+    ref_goal_size = min(
+        round(labels_in.label_count * ref_max_ratio),
+        config.TRAINING_BATCH_LABEL_COUNT)
+    val_goal_size = round(labels_in.label_count * val_ratio)
+    train_goal_size = (
+        labels_in.label_count - ref_goal_size - val_goal_size)
+
+    # Preempt set-size ValueErrors that would be raised from
+    # train_test_split().
+    # TrainingLabelErrors are more specific and thus should be nicer for
+    # error handling.
+
+    if class_sampling == ClassSamplingMethod.IGNORE:
+        set_minimum_size = 1
+        explanation = "Each set must be non-empty."
+    else:
+        # Stratified by class
+        set_minimum_size = len(labels_in.classes_set)
+        explanation = (
+            f"Each set's size must not be less than the number of classes"
+            f" ({set_minimum_size}) to work with train_test_split().")
+    if ref_goal_size < set_minimum_size \
+            or val_goal_size < set_minimum_size \
+            or train_goal_size < set_minimum_size:
+        raise TrainingLabelsError(
+            f"Not enough annotations to populate train/ref/val sets."
+            f" Split was calculated as"
+            f" {train_goal_size}/{ref_goal_size}/{val_goal_size}."
+            f" {explanation}"
+        )
+
+    # Add annotations to the three sets.
+
+    train_data = defaultdict(list)
+    ref_data = defaultdict(list)
+    val_data = defaultdict(list)
+
+    # Map integer indices to image keys.
+    # This is just a list, and the 'lookup keys' are the list indices.
+    #
+    # We want this so we have smaller identifiers for each image
+    # (int instead of an arbitrary string)
+    # to use in the potentially very long, RAM-consuming lists below.
+    image_lookup = labels_in.image_keys
+    # Flat lists of annotation identifiers (image index +
+    # annotation-in-image index) and labels.
+    annotation_indices_flat = []
+    labels_flat = []
+
+    for image_index, image_key in enumerate(image_lookup):
+        for annotation_index, annotation in enumerate(labels_in[image_key]):
+            _row, _column, label = annotation
+            annotation_indices_flat.append((image_index, annotation_index))
+            labels_flat.append(label)
+
+    # Leave the split to scikit-learn. It can only split a set into two,
+    # so we first make it do a train+ref / val split, then a train / ref
+    # split.
+    # See ClassSamplingMethod for details on stratification.
+
+    train_ref_indices, val_indices = train_test_split(
+        annotation_indices_flat,
+        test_size=val_goal_size, random_state=0, shuffle=True,
+        stratify=(
+            None if class_sampling == ClassSamplingMethod.IGNORE
+            else labels_flat),
+    )
+
+    annotation_indices_flat_reverse_lookup = {
+        annotation_index_pair: list_index
+        for list_index, annotation_index_pair
+        in enumerate(annotation_indices_flat)
+    }
+    train_ref_labels_flat = []
+    for annotation_index_pair in train_ref_indices:
+        index_into_all_annotations = \
+            annotation_indices_flat_reverse_lookup[annotation_index_pair]
+        train_ref_labels_flat.append(labels_flat[index_into_all_annotations])
+
+    train_indices, ref_indices = train_test_split(
+        train_ref_indices,
+        test_size=ref_goal_size, random_state=0, shuffle=True,
+        stratify=(
+            None if class_sampling == ClassSamplingMethod.IGNORE
+            else train_ref_labels_flat),
+    )
+
+    for set_indices, set_data in [
+        (train_indices, train_data),
+        (ref_indices, ref_data),
+        (val_indices, val_data),
+    ]:
+        for image_index, annotation_index in set_indices:
+            image_key = image_lookup[image_index]
+            set_data[image_key].append(
+                labels_in[image_key][annotation_index])
+
+    return TrainingTaskLabels(
+        train=ImageLabels(train_data),
+        ref=ImageLabels(ref_data),
+        val=ImageLabels(val_data),
+    )
+
+
 def preprocess_labels(
-        # Training labels (annotations); two acceptable formats:
-        #
-        # 1) An ImageLabels instance, which this function decides how to
-        # split up into training, reference, and validation sets.
-        # 2) A dict which has keys 'train', 'ref', and 'val',
-        # each mapping to a separate ImageLabels instance.
-        labels_in: ImageLabels | TrainingTaskLabels,
-        # If present, the passed labels are filtered so that any classes not
-        # included in this set have their labels discarded.
-        accepted_classes: set[int] | None = None) -> TrainingTaskLabels:
+    # Training labels (annotations); two acceptable formats:
+    #
+    # 1) An ImageLabels instance, which this function decides how to
+    # split up into training, reference, and validation sets.
+    # 2) A dict which has keys 'train', 'ref', and 'val',
+    # each mapping to a separate ImageLabels instance.
+    labels_in: ImageLabels | TrainingTaskLabels,
+    # If present, the passed labels are filtered so that any classes not
+    # included in this set have their labels discarded.
+    accepted_classes: set[int] | None = None,
+    # See split_labels().
+    split_ratios: tuple[float, float] = (0.1, 0.1),
+    # See split_labels().
+    class_sampling: ClassSamplingMethod = ClassSamplingMethod.STRATIFIED,
+) -> TrainingTaskLabels:
     """
     This function can be used to preprocess labels before creating a
     TrainClassifierMsg. It does:
@@ -88,52 +237,10 @@ def preprocess_labels(
         # training, reference, and validation sets.
         labels = labels_in
     else:
-        # Split data into training, reference, and validation sets.
-        #
-        # Arbitrarily, validation gets 10%, reference gets
-        # min(10%, TRAINING_BATCH_LABEL_COUNT), training gets the rest.
-        # This is imprecise because it's split on the image level, not the
-        # label level, and images can have different numbers of labels.
-        #
-        # The split is done in a way which guarantees that all 3 sets are
-        # non-empty if there are at least 3 images.
-        if len(labels_in) < 3:
-            raise TrainingLabelsError(
-                f"The training data has {len(labels_in)} image(s),"
-                f" but need at least 3 to populate train/ref/val sets.")
-
-        train_data = dict()
-        ref_data = dict()
-        val_data = dict()
-        ref_label_count = 0
-        ref_done = False
-
-        for image_index, image_key in enumerate(labels_in.image_keys):
-            this_image_labels = labels_in[image_key]
-
-            if image_index % 10 == 0:
-                # 1st, 11th, 21st, etc. images go in val.
-                val_data[image_key] = this_image_labels
-            elif not ref_done and image_index % 10 == 1:
-                # 2nd, 12th, 22nd, etc. images go in ref, if ref still
-                # has room within the batch size; else, go in train.
-                if (ref_label_count + len(this_image_labels)
-                        <= config.TRAINING_BATCH_LABEL_COUNT):
-                    ref_data[image_key] = this_image_labels
-                    ref_label_count += len(this_image_labels)
-                else:
-                    # ref would go over the batch size if it added this
-                    # image.
-                    train_data[image_key] = this_image_labels
-                    ref_done = True
-            else:
-                # The rest go in train.
-                train_data[image_key] = this_image_labels
-
-        labels = TrainingTaskLabels(
-            train=ImageLabels(train_data),
-            ref=ImageLabels(ref_data),
-            val=ImageLabels(val_data),
+        labels = split_labels(
+            labels_in,
+            split_ratios=split_ratios,
+            class_sampling=class_sampling,
         )
 
     # Identify classes common to both train and ref.
@@ -142,6 +249,11 @@ def preprocess_labels(
     train_ref_classes = train_classes.intersection(ref_classes)
 
     # Further filter the classes if this arg was specified.
+    # TODO: Filter by accepted_classes earlier, before the train/ref/val
+    #  split, because that can potentially alter the annotation count a
+    #  lot. Keep the train+ref class-set filtering step here, because that
+    #  filtering step shouldn't alter the count much, and requires knowing
+    #  the train and ref sets in the first place.
     if accepted_classes:
         classes_filter = \
             train_ref_classes.intersection(accepted_classes)

--- a/spacer/task_utils.py
+++ b/spacer/task_utils.py
@@ -8,7 +8,7 @@ from PIL import Image
 from sklearn.model_selection import train_test_split
 
 from spacer import config
-from spacer.data_classes import ImageLabels
+from spacer.data_classes import ImageLabels, LabelId
 from spacer.exceptions import (
     DataLimitError, RowColumnInvalidError, TrainingLabelsError)
 from spacer.messages import TrainingTaskLabels
@@ -295,7 +295,7 @@ def preprocess_labels(
     labels_in: ImageLabels | TrainingTaskLabels,
     # If present, the passed labels are filtered so that any classes not
     # included in this set have their labels discarded.
-    accepted_classes: set[int] | None = None,
+    accepted_classes: set[LabelId] | None = None,
     # See split_labels().
     split_ratios: tuple[float, float] = (0.1, 0.1),
     # See split_labels().

--- a/spacer/tests/test_task_utils.py
+++ b/spacer/tests/test_task_utils.py
@@ -6,7 +6,7 @@ from PIL import Image
 from spacer.exceptions import RowColumnInvalidError, TrainingLabelsError
 from spacer.messages import DataLocation, ImageLabels, TrainingTaskLabels
 from spacer.task_utils import (
-    check_extract_inputs, ClassSamplingMethod, preprocess_labels)
+    check_extract_inputs, preprocess_labels, SplitMode)
 from spacer.train_utils import make_random_data
 
 
@@ -61,7 +61,7 @@ class TestRowColChecks(unittest.TestCase):
             " valid range of 0-99.")
 
 
-class TestPreprocessLabels(unittest.TestCase):
+class TestSplitLabels(unittest.TestCase):
 
     def test_train_ref_val_split(self):
         """
@@ -108,8 +108,8 @@ class TestPreprocessLabels(unittest.TestCase):
         self.assertEqual(labels['val'].label_count, 6000)
 
     def test_custom_split_ratio(self):
-        n_data = 2
-        points_per_image = 200
+        n_data = 10
+        points_per_image = 10
         feature_dim = 5
         class_list = [1, 2]
         features_loc_template = DataLocation(storage_type='memory', key='')
@@ -119,17 +119,17 @@ class TestPreprocessLabels(unittest.TestCase):
                 n_data, class_list, points_per_image,
                 feature_dim, features_loc_template,
             ),
-            split_ratios=(0.01, 0.15),
+            split_ratios=(0.2, 0.3),
         )
 
-        # 84% 1% 15%
-        self.assertEqual(labels['train'].label_count, 336)
-        self.assertEqual(labels['ref'].label_count, 4)
-        self.assertEqual(labels['val'].label_count, 60)
+        # 50% 20% 30%
+        self.assertEqual(labels['train'].label_count, 50)
+        self.assertEqual(labels['ref'].label_count, 20)
+        self.assertEqual(labels['val'].label_count, 30)
 
-    def test_just_enough_annotations_non_stratified(self):
-        n_data = 1
-        points_per_image = 20
+    def test_vectors_imprecise_split(self):
+        n_data = 10
+        points_per_image = 10
         feature_dim = 5
         class_list = [1, 2]
         features_loc_template = DataLocation(storage_type='memory', key='')
@@ -139,19 +139,112 @@ class TestPreprocessLabels(unittest.TestCase):
                 n_data, class_list, points_per_image,
                 feature_dim, features_loc_template,
             ),
-            # There is another error concerning not having enough unique
+            split_ratios=(0.26, 0.24),
+            split_mode=SplitMode.VECTORS,
+        )
+
+        # The rest, 26% rounded up to nearest vector, 24% rounded up to
+        # nearest vector
+        self.assertEqual(labels['train'].label_count, 40)
+        self.assertEqual(labels['ref'].label_count, 30)
+        self.assertEqual(labels['val'].label_count, 30)
+
+    def test_points_precise_split(self):
+        n_data = 10
+        points_per_image = 10
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            split_ratios=(0.26, 0.24),
+            split_mode=SplitMode.POINTS,
+        )
+
+        # 50%, 26%, 24%; exact despite having 10 points per feature vector
+        self.assertEqual(labels['train'].label_count, 50)
+        self.assertEqual(labels['ref'].label_count, 26)
+        self.assertEqual(labels['val'].label_count, 24)
+
+    def test_vectors_keep_vectors_together(self):
+        n_data = 10
+        points_per_image = 10
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            split_ratios=(0.2, 0.2),
+            split_mode=SplitMode.VECTORS,
+        )
+
+        # If each vector is entirely in one set, then these should be the
+        # number of vectors in each set.
+        self.assertEqual(len(labels['train'].image_keys), 6)
+        self.assertEqual(len(labels['ref'].image_keys), 2)
+        self.assertEqual(len(labels['val'].image_keys), 2)
+
+    def test_points_dont_keep_vectors_together(self):
+        n_data = 10
+        points_per_image = 10
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            split_ratios=(0.2, 0.2),
+            split_mode=SplitMode.POINTS,
+        )
+
+        # It should be exceedingly unlikely for every vector to have all
+        # 10 of its points in one set. That is, we expect at least one
+        # image key to appear in two or more sets.
+        self.assertGreater(
+            len(labels['train'].image_keys)
+            + len(labels['ref'].image_keys)
+            + len(labels['val'].image_keys),
+            10,
+        )
+
+    def test_points_just_enough_annotations(self):
+        n_data = 1
+        points_per_image = 100
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            # There is another error concerning not having 2+ unique
             # classes in the ref set which we don't want to test here, so
             # we make the ref set large enough to generally avoid that.
-            split_ratios=(0.25, 0.0251),
-            class_sampling=ClassSamplingMethod.IGNORE,
+            # (25 random points drawn from [1, 2] probably aren't going
+            # to be all 1, or all 2.)
+            split_ratios=(0.25, 0.0051),
+            split_mode=SplitMode.POINTS,
         )
-        self.assertEqual(labels['train'].label_count, 14)
-        self.assertEqual(labels['ref'].label_count, 5)
+        self.assertEqual(labels['train'].label_count, 74)
+        self.assertEqual(labels['ref'].label_count, 25)
         self.assertEqual(labels['val'].label_count, 1)
 
-    def test_too_few_annotations_non_stratified(self):
+    def test_points_too_few_annotations(self):
         n_data = 1
-        points_per_image = 20
+        points_per_image = 100
         feature_dim = 5
         class_list = [1, 2]
         features_loc_template = DataLocation(storage_type='memory', key='')
@@ -162,16 +255,16 @@ class TestPreprocessLabels(unittest.TestCase):
                     n_data, class_list, points_per_image,
                     feature_dim, features_loc_template,
                 ),
-                split_ratios=(0.25, 0.0249),
-                class_sampling=ClassSamplingMethod.IGNORE,
+                split_ratios=(0.25, 0.0049),
+                split_mode=SplitMode.POINTS,
             )
         self.assertEqual(
             str(cm.exception),
             f"Not enough annotations to populate train/ref/val sets."
-            f" Split was calculated as 15/5/0."
+            f" Split was calculated as 75/25/0."
             f" Each set must be non-empty.")
 
-    def test_just_enough_annotations_stratified(self):
+    def test_points_stratified_just_enough_annotations(self):
         labels = preprocess_labels(
             # classes [1, 2, 3], 25 annotations
             ImageLabels({
@@ -180,13 +273,13 @@ class TestPreprocessLabels(unittest.TestCase):
                       *[(n, n, 3) for n in range(200, 208)]],
             }),
             split_ratios=(0.101, 0.2),
-            class_sampling=ClassSamplingMethod.STRATIFIED,
+            split_mode=SplitMode.POINTS_STRATIFIED,
         )
         self.assertEqual(labels['train'].label_count, 17)
         self.assertEqual(labels['ref'].label_count, 3)
         self.assertEqual(labels['val'].label_count, 5)
 
-    def test_too_few_annotations_stratified(self):
+    def test_points_stratified_too_few_annotations(self):
         with self.assertRaises(TrainingLabelsError) as cm:
             preprocess_labels(
                 # classes [1, 2, 3], 25 annotations
@@ -196,7 +289,7 @@ class TestPreprocessLabels(unittest.TestCase):
                           *[(n, n, 3) for n in range(200, 208)]],
                 }),
                 split_ratios=(0.099, 0.2),
-                class_sampling=ClassSamplingMethod.STRATIFIED,
+                split_mode=SplitMode.POINTS_STRATIFIED,
             )
         self.assertEqual(
             str(cm.exception),
@@ -205,6 +298,139 @@ class TestPreprocessLabels(unittest.TestCase):
             f" Each set's size must not be less than the number of classes"
             f" (3) to work with train_test_split().")
 
+    @staticmethod
+    def count_of_label(annotations: ImageLabels, label: int):
+        return len([
+            anno_label for row, column, anno_label in annotations
+            if anno_label == label
+        ])
+
+    def test_stratify_by_classes(self):
+        labels = preprocess_labels(
+            ImageLabels({
+                # Annotations per class: 60, 20, 10.
+                # The 60 are split between 2 groups of 50/10 so things aren't
+                # completely in order.
+                '1': [*[(n, n, 1) for n in range(0, 50)],
+                      *[(n, n, 2) for n in range(100, 120)],
+                      *[(n, n, 3) for n in range(200, 210)],
+                      *[(n, n, 1) for n in range(400, 410)]],
+            }),
+            split_mode=SplitMode.POINTS_STRATIFIED,
+        )
+
+        self.assertEqual(
+            self.count_of_label(labels.train['1'], 1), 48)
+        self.assertEqual(
+            self.count_of_label(labels.ref['1'], 1), 6)
+        self.assertEqual(
+            self.count_of_label(labels.val['1'], 1), 6)
+
+        self.assertEqual(
+            self.count_of_label(labels.train['1'], 2), 16)
+        self.assertEqual(
+            self.count_of_label(labels.ref['1'], 2), 2)
+        self.assertEqual(
+            self.count_of_label(labels.val['1'], 2), 2)
+
+        self.assertEqual(
+            self.count_of_label(labels.train['1'], 3), 8)
+        self.assertEqual(
+            self.count_of_label(labels.ref['1'], 3), 1)
+        self.assertEqual(
+            self.count_of_label(labels.val['1'], 3), 1)
+
+    def test_stratify_with_many_uncommon_classes(self):
+        # 10 of each of 100 classes.
+        labels_data = []
+        for class_number in range(1, 100+1):
+            labels_data.extend([
+                (coord, coord, class_number)
+                for coord in range(class_number*10, class_number*10+10)
+            ])
+        # Pre-shuffle to ensure stratification doesn't rely on the ordering
+        # in some way.
+        random.shuffle(labels_data)
+        labels = preprocess_labels(
+            ImageLabels({
+                '1': labels_data,
+            }),
+            split_mode=SplitMode.POINTS_STRATIFIED,
+        )
+
+        for class_number in range(1, 100+1):
+            self.assertEqual(
+                self.count_of_label(labels.train['1'], class_number), 8,
+                msg=f"Class {class_number} should have 8 instances in train",
+            )
+            self.assertEqual(
+                self.count_of_label(labels.ref['1'], class_number), 1,
+                msg=f"Class {class_number} should have 1 instance in ref",
+            )
+            self.assertEqual(
+                self.count_of_label(labels.val['1'], class_number), 1,
+                msg=f"Class {class_number} should have 1 instance in val",
+            )
+
+    def test_stratify_with_too_rare_classes(self):
+        """
+        Classes with less than 3 annotations shouldn't cause issues
+        for stratified splitting.
+        We expect them to get excluded before splitting.
+        """
+        labels = preprocess_labels(
+            ImageLabels({
+                '1': [*[(n, n, 1) for n in range(0, 50)],
+                      *[(n, n, 2) for n in range(100, 103)],
+                      *[(n, n, 3) for n in range(200, 202)],
+                      *[(n, n, 4) for n in range(300, 301)],
+                      *[(n, n, 5) for n in range(400, 410)]],
+            }),
+            # Ensure the filtering by train+ref doesn't exclude anything,
+            # by giving ref a high ratio of 40%.
+            split_ratios=(0.4, 0.1),
+            split_mode=SplitMode.POINTS_STRATIFIED,
+        )
+
+        included_classes = labels.train.classes_set.union(
+            labels.ref.classes_set, labels.val.classes_set
+        )
+        self.assertSetEqual(
+            {1, 2, 5}, included_classes,
+            msg="Classes 3 and 4 should be excluded")
+
+    def test_do_not_stratify(self):
+        # 10 of each of 100 classes.
+        labels_data = []
+        for class_number in range(1, 100+1):
+            labels_data.extend([
+                (coord, coord, class_number)
+                for coord in range(class_number*10, class_number*10+10)
+            ])
+        # Pre-shuffle to ensure the split doesn't rely on the ordering
+        # in some way.
+        random.shuffle(labels_data)
+        labels = preprocess_labels(
+            ImageLabels({
+                '1': labels_data,
+            }),
+            split_mode=SplitMode.POINTS,
+        )
+
+        booleans = [
+            self.count_of_label(labels.train['1'], class_number) == 8
+            for class_number in range(1, 100+1)
+        ]
+        self.assertFalse(
+            all(booleans),
+            msg="The chances of perfect stratification without having"
+                " stratification on should be basically zero")
+
+
+class TestPreprocessLabels(unittest.TestCase):
+    """
+    Testing the rest of preprocess_labels() besides splitting.
+    """
     def test_train_ref_1_common_class(self):
         points_per_image = 20
         feature_dim = 5
@@ -289,130 +515,6 @@ class TestPreprocessLabels(unittest.TestCase):
         self.assertEqual(labels.val['3'], [(100, 100, 1), (200, 200, 2)])
         self.assertNotIn(
             '4', labels.val, msg="Image 4 should be excluded entirely")
-
-    @staticmethod
-    def count_of_label(annotations: ImageLabels, label: int):
-        return len([
-            anno_label for row, column, anno_label in annotations
-            if anno_label == label
-        ])
-
-    def test_stratify_by_classes(self):
-        labels = preprocess_labels(ImageLabels({
-            # Annotations per class: 60, 20, 10.
-            # The 60 are split between 2 groups of 50/10 so things aren't
-            # completely in order.
-            '1': [*[(n, n, 1) for n in range(0, 50)],
-                  *[(n, n, 2) for n in range(100, 120)],
-                  *[(n, n, 3) for n in range(200, 210)],
-                  *[(n, n, 1) for n in range(400, 410)]],
-        }))
-
-        # train_test_split() gets some fluctuating counts unfortunately,
-        # but it does guarantee at least 1 of each class in each set.
-        self.assertEqual(
-            self.count_of_label(labels.train['1'], 1), 48)
-        self.assertEqual(
-            self.count_of_label(labels.ref['1'], 1), 6)
-        self.assertEqual(
-            self.count_of_label(labels.val['1'], 1), 6)
-
-        self.assertEqual(
-            self.count_of_label(labels.train['1'], 2), 16)
-        self.assertEqual(
-            self.count_of_label(labels.ref['1'], 2), 2)
-        self.assertEqual(
-            self.count_of_label(labels.val['1'], 2), 2)
-
-        self.assertEqual(
-            self.count_of_label(labels.train['1'], 3), 8)
-        self.assertEqual(
-            self.count_of_label(labels.ref['1'], 3), 1)
-        self.assertEqual(
-            self.count_of_label(labels.val['1'], 3), 1)
-
-    def test_stratify_with_many_uncommon_classes(self):
-        # 10 of each of 100 classes.
-        labels_data = []
-        for class_number in range(1, 100+1):
-            labels_data.extend([
-                (coord, coord, class_number)
-                for coord in range(class_number*10, class_number*10+10)
-            ])
-        # Pre-shuffle to ensure stratification doesn't rely on the ordering
-        # in some way.
-        random.shuffle(labels_data)
-        labels = preprocess_labels(ImageLabels({
-            '1': labels_data,
-        }))
-
-        for class_number in range(1, 100+1):
-            self.assertEqual(
-                self.count_of_label(labels.train['1'], class_number), 8,
-                msg=f"Class {class_number} should have 8 instances in train",
-            )
-            self.assertEqual(
-                self.count_of_label(labels.ref['1'], class_number), 1,
-                msg=f"Class {class_number} should have 1 instance in ref",
-            )
-            self.assertEqual(
-                self.count_of_label(labels.val['1'], class_number), 1,
-                msg=f"Class {class_number} should have 1 instance in val",
-            )
-
-    def test_stratify_with_too_rare_classes(self):
-        """
-        Classes with less than 3 annotations shouldn't cause issues
-        for stratified splitting.
-        We expect them to get excluded before splitting.
-        """
-        labels = preprocess_labels(
-            ImageLabels({
-                '1': [*[(n, n, 1) for n in range(0, 50)],
-                      *[(n, n, 2) for n in range(100, 103)],
-                      *[(n, n, 3) for n in range(200, 202)],
-                      *[(n, n, 4) for n in range(300, 301)],
-                      *[(n, n, 5) for n in range(400, 410)]],
-            }),
-            # Ensure the filtering by train+ref doesn't exclude anything,
-            # by giving ref a high ratio of 40%.
-            split_ratios=(0.4, 0.1),
-            class_sampling=ClassSamplingMethod.STRATIFIED,
-        )
-
-        included_classes = labels.train.classes_set.union(
-            labels.ref.classes_set, labels.val.classes_set
-        )
-        self.assertSetEqual(
-            {1, 2, 5}, included_classes,
-            msg="Classes 3 and 4 should be excluded")
-
-    def test_ignore_classes(self):
-        # 10 of each of 100 classes.
-        labels_data = []
-        for class_number in range(1, 100+1):
-            labels_data.extend([
-                (coord, coord, class_number)
-                for coord in range(class_number*10, class_number*10+10)
-            ])
-        # Pre-shuffle to ensure the split doesn't rely on the ordering
-        # in some way.
-        random.shuffle(labels_data)
-        labels = preprocess_labels(
-            ImageLabels({
-                '1': labels_data,
-            }),
-            class_sampling=ClassSamplingMethod.IGNORE,
-        )
-
-        booleans = [
-            self.count_of_label(labels.train['1'], class_number) == 8
-            for class_number in range(1, 100+1)
-        ]
-        self.assertFalse(
-            all(booleans),
-            msg="The chances of perfect stratification without having"
-                " stratification on should be basically zero")
 
 
 if __name__ == '__main__':

--- a/spacer/tests/test_task_utils.py
+++ b/spacer/tests/test_task_utils.py
@@ -3,6 +3,7 @@ import unittest
 
 from PIL import Image
 
+from spacer.data_classes import LabelId
 from spacer.exceptions import RowColumnInvalidError, TrainingLabelsError
 from spacer.messages import DataLocation, ImageLabels, TrainingTaskLabels
 from spacer.task_utils import (
@@ -299,7 +300,7 @@ class TestSplitLabels(unittest.TestCase):
             f" (3) to work with train_test_split().")
 
     @staticmethod
-    def count_of_label(annotations: ImageLabels, label: int):
+    def count_of_label(annotations: ImageLabels, label: LabelId):
         return len([
             anno_label for row, column, anno_label in annotations
             if anno_label == label

--- a/spacer/tests/test_task_utils.py
+++ b/spacer/tests/test_task_utils.py
@@ -1,10 +1,12 @@
+import random
 import unittest
 
 from PIL import Image
 
 from spacer.exceptions import RowColumnInvalidError, TrainingLabelsError
 from spacer.messages import DataLocation, ImageLabels, TrainingTaskLabels
-from spacer.task_utils import check_extract_inputs, preprocess_labels
+from spacer.task_utils import (
+    check_extract_inputs, ClassSamplingMethod, preprocess_labels)
 from spacer.train_utils import make_random_data
 
 
@@ -77,9 +79,9 @@ class TestPreprocessLabels(unittest.TestCase):
         ))
 
         # 80% 10% 10%
-        self.assertEqual(len(labels['train']), 16)
-        self.assertEqual(len(labels['ref']), 2)
-        self.assertEqual(len(labels['val']), 2)
+        self.assertEqual(labels['train'].label_count, 160)
+        self.assertEqual(labels['ref'].label_count, 20)
+        self.assertEqual(labels['val'].label_count, 20)
 
     def test_train_ref_val_split_large(self):
         """
@@ -101,26 +103,115 @@ class TestPreprocessLabels(unittest.TestCase):
         ))
 
         # 80%+ (capped to 5000 points) 10%
-        self.assertEqual(len(labels['train']), 49)
-        self.assertEqual(len(labels['ref']), 5)
-        self.assertEqual(len(labels['val']), 6)
+        self.assertEqual(labels['train'].label_count, 49000)
+        self.assertEqual(labels['ref'].label_count, 5000)
+        self.assertEqual(labels['val'].label_count, 6000)
 
-    def test_too_few_images(self):
+    def test_custom_split_ratio(self):
         n_data = 2
-        points_per_image = 5
+        points_per_image = 200
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            split_ratios=(0.01, 0.15),
+        )
+
+        # 84% 1% 15%
+        self.assertEqual(labels['train'].label_count, 336)
+        self.assertEqual(labels['ref'].label_count, 4)
+        self.assertEqual(labels['val'].label_count, 60)
+
+    def test_just_enough_annotations_non_stratified(self):
+        n_data = 1
+        points_per_image = 20
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            # There is another error concerning not having enough unique
+            # classes in the ref set which we don't want to test here, so
+            # we make the ref set large enough to generally avoid that.
+            split_ratios=(0.25, 0.0251),
+            class_sampling=ClassSamplingMethod.IGNORE,
+        )
+        self.assertEqual(labels['train'].label_count, 14)
+        self.assertEqual(labels['ref'].label_count, 5)
+        self.assertEqual(labels['val'].label_count, 1)
+
+    def test_too_few_annotations_non_stratified(self):
+        n_data = 1
+        points_per_image = 20
         feature_dim = 5
         class_list = [1, 2]
         features_loc_template = DataLocation(storage_type='memory', key='')
 
         with self.assertRaises(TrainingLabelsError) as cm:
-            preprocess_labels(make_random_data(
-                n_data, class_list, points_per_image,
-                feature_dim, features_loc_template,
-            ))
+            preprocess_labels(
+                make_random_data(
+                    n_data, class_list, points_per_image,
+                    feature_dim, features_loc_template,
+                ),
+                split_ratios=(0.25, 0.0249),
+                class_sampling=ClassSamplingMethod.IGNORE,
+            )
         self.assertEqual(
             str(cm.exception),
-            "The training data has 2 image(s), but need at least 3"
-            " to populate train/ref/val sets.")
+            f"Not enough annotations to populate train/ref/val sets."
+            f" Split was calculated as 15/5/0."
+            f" Each set must be non-empty.")
+
+    def test_just_enough_annotations_stratified(self):
+        n_data = 1
+        points_per_image = 25
+        feature_dim = 5
+        class_list = [1, 2, 3]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            split_ratios=(0.101, 0.2),
+            class_sampling=ClassSamplingMethod.STRATIFIED,
+        )
+        self.assertEqual(labels['train'].label_count, 17)
+        self.assertEqual(labels['ref'].label_count, 3)
+        self.assertEqual(labels['val'].label_count, 5)
+
+    def test_too_few_annotations_stratified(self):
+        n_data = 1
+        points_per_image = 25
+        feature_dim = 5
+        class_list = [1, 2, 3]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        with self.assertRaises(TrainingLabelsError) as cm:
+            preprocess_labels(
+                make_random_data(
+                    n_data, class_list, points_per_image,
+                    feature_dim, features_loc_template,
+                ),
+                split_ratios=(0.099, 0.2),
+                class_sampling=ClassSamplingMethod.STRATIFIED,
+            )
+        self.assertEqual(
+            str(cm.exception),
+            f"Not enough annotations to populate train/ref/val sets."
+            f" Split was calculated as 18/2/5."
+            f" Each set's size must not be less than the number of classes"
+            f" (3) to work with train_test_split().")
 
     def test_train_ref_1_common_class(self):
         points_per_image = 20
@@ -206,6 +297,103 @@ class TestPreprocessLabels(unittest.TestCase):
         self.assertEqual(labels.val['3'], [(100, 100, 1), (200, 200, 2)])
         self.assertNotIn(
             '4', labels.val, msg="Image 4 should be excluded entirely")
+
+    @staticmethod
+    def count_of_label(annotations: ImageLabels, label: int):
+        return len([
+            anno_label for row, column, anno_label in annotations
+            if anno_label == label
+        ])
+
+    def test_stratify_by_classes(self):
+        labels = preprocess_labels(ImageLabels({
+            # Annotations per class: 60, 20, 10.
+            # The 60 are split between 2 groups of 50/10 so things aren't
+            # completely in order.
+            '1': [*[(n, n, 1) for n in range(0, 50)],
+                  *[(n, n, 2) for n in range(100, 120)],
+                  *[(n, n, 3) for n in range(200, 210)],
+                  *[(n, n, 1) for n in range(400, 410)]],
+        }))
+
+        # train_test_split() gets some fluctuating counts unfortunately,
+        # but it does guarantee at least 1 of each class in each set.
+        self.assertEqual(
+            self.count_of_label(labels.train['1'], 1), 48)
+        self.assertEqual(
+            self.count_of_label(labels.ref['1'], 1), 6)
+        self.assertEqual(
+            self.count_of_label(labels.val['1'], 1), 6)
+
+        self.assertEqual(
+            self.count_of_label(labels.train['1'], 2), 16)
+        self.assertEqual(
+            self.count_of_label(labels.ref['1'], 2), 2)
+        self.assertEqual(
+            self.count_of_label(labels.val['1'], 2), 2)
+
+        self.assertEqual(
+            self.count_of_label(labels.train['1'], 3), 8)
+        self.assertEqual(
+            self.count_of_label(labels.ref['1'], 3), 1)
+        self.assertEqual(
+            self.count_of_label(labels.val['1'], 3), 1)
+
+    def test_stratify_with_many_uncommon_classes(self):
+        # 10 of each of 100 classes.
+        labels_data = []
+        for class_number in range(1, 100+1):
+            labels_data.extend([
+                (coord, coord, class_number)
+                for coord in range(class_number*10, class_number*10+10)
+            ])
+        # Pre-shuffle to ensure stratification doesn't rely on the ordering
+        # in some way.
+        random.shuffle(labels_data)
+        labels = preprocess_labels(ImageLabels({
+            '1': labels_data,
+        }))
+
+        for class_number in range(1, 100+1):
+            self.assertEqual(
+                self.count_of_label(labels.train['1'], class_number), 8,
+                msg=f"Class {class_number} should have 8 instances in train",
+            )
+            self.assertEqual(
+                self.count_of_label(labels.ref['1'], class_number), 1,
+                msg=f"Class {class_number} should have 1 instance in ref",
+            )
+            self.assertEqual(
+                self.count_of_label(labels.val['1'], class_number), 1,
+                msg=f"Class {class_number} should have 1 instance in val",
+            )
+
+    def test_ignore_classes(self):
+        # 10 of each of 100 classes.
+        labels_data = []
+        for class_number in range(1, 100+1):
+            labels_data.extend([
+                (coord, coord, class_number)
+                for coord in range(class_number*10, class_number*10+10)
+            ])
+        # Pre-shuffle to ensure the split doesn't rely on the ordering
+        # in some way.
+        random.shuffle(labels_data)
+        labels = preprocess_labels(
+            ImageLabels({
+                '1': labels_data,
+            }),
+            class_sampling=ClassSamplingMethod.IGNORE,
+        )
+
+        booleans = [
+            self.count_of_label(labels.train['1'], class_number) == 8
+            for class_number in range(1, 100+1)
+        ]
+        self.assertFalse(
+            all(booleans),
+            msg="The chances of perfect stratification without having"
+                " stratification on should be basically zero")
 
 
 if __name__ == '__main__':

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -4,7 +4,7 @@ from PIL import Image
 
 from spacer import config
 from spacer.data_classes import (
-    ImageFeatures, ImageLabels, PointFeatures, ValResults)
+    ImageFeatures, ImageLabels, LabelId, PointFeatures, ValResults)
 from spacer.exceptions import (
     DataLimitError, RowColumnInvalidError, RowColumnMismatchError)
 from spacer.extract_features import DummyExtractor
@@ -308,7 +308,7 @@ class ClassifyReturnMsgTest(unittest.TestCase):
                 self.assertIsNone(col)
 
         for class_ in return_msg.classes:
-            self.assertTrue(isinstance(class_, int))
+            self.assertTrue(isinstance(class_, LabelId))
 
         self.assertTrue(isinstance(return_msg.valid_rowcol, bool))
 

--- a/spacer/tests/test_train_utils.py
+++ b/spacer/tests/test_train_utils.py
@@ -4,7 +4,8 @@ import unittest
 import numpy as np
 
 from spacer import config
-from spacer.data_classes import ImageLabels, PointFeatures, ImageFeatures
+from spacer.data_classes import (
+    Annotation, ImageLabels, PointFeatures, ImageFeatures)
 from spacer.exceptions import RowColumnInvalidError, RowColumnMismatchError
 from spacer.messages import DataLocation
 from spacer.train_utils import (
@@ -278,10 +279,8 @@ class TestAcc(unittest.TestCase):
 
     def test_simple(self):
         self.assertEqual(calc_acc([1, 2, 3, 11], [1, 2, 1, 4]), 0.5)
-        self.assertRaises(TypeError, calc_acc, [], [])
+        self.assertRaises(ValueError, calc_acc, [], [])
         self.assertRaises(ValueError, calc_acc, [1], [2, 1])
-        self.assertRaises(TypeError, calc_acc, [1.1], [1])
-        self.assertRaises(TypeError, calc_acc, [1], [1.1])
 
 
 class TestLoadImageData(unittest.TestCase):
@@ -294,7 +293,7 @@ class TestLoadImageData(unittest.TestCase):
                                        key=cls.feat_key)
 
     def fixtures(self, in_order=True, valid_rowcol=True) \
-            -> tuple[list[tuple[int, int, int]], ImageFeatures]:
+            -> tuple[list[Annotation], ImageFeatures]:
 
         labels = [(100, 100, 1),
                   (200, 200, 2),


### PR DESCRIPTION
From Mermaid Trello card:

> Since Mermaid thus far has used UUIDs, not integer IDs, for BAGFs.
> 
> CoralNet has always used integer IDs for everything in its database, so I believe that design assumption just carried over to the way that pyspacer identifies labels (classes). I couldn’t think of any reason why this would need to be an integer. The values do get passed into scikit-learn’s `MLPClassifier` and `SGDClassifier`, but the relevant methods/fields `predict()`, `predict_proba()`, and `classes_` seem to take an array of any type.
> 
> This would involve relaxing the parameter type annotations in various functions/methods such as `ImageLabels.__init__()`, `ImageLabels.unique_classes()`, `load_image_data()`, `load_batch_data()`, `evaluate_classifier()`, and `make_random_data()`. I think `make_random_data()` does actually use the parameter as an int (or at least something that’s addable to a float), but that doesn’t seem to be a necessary implementation detail. Of note, `ValResults` actually uses indices into a list of labels, rather than using the label representations themselves, so some stuff related to `ValResults` won't need changing.
> 
> I’d probably define a custom data type `LabelId` which is an alias of `Hashable`. So if we ever decide that `Hashable` isn’t quite what we wanted for label IDs, that’ll be easier to change next time.

This plan ran into a hitch though: a `uuid.UUID`, which is Hashable, got this sort of error when used for training:

```
Traceback (most recent call last):
  File "D:\CVCE\Site\pyspacer\spacer\tests\test_tasks.py", line 190, in test_default
    clf, _ = train(
  File "D:\CVCE\Site\pyspacer\spacer\train_utils.py", line 73, in train
    clf.partial_fit(x, y, classes=classes_list)
  File "D:\Code_environments\venv_coralnet_py310\lib\site-packages\sklearn\linear_model\_stochastic_gradient.py", line 848, in partial_fit
    return self._partial_fit(
  File "D:\Code_environments\venv_coralnet_py310\lib\site-packages\sklearn\linear_model\_stochastic_gradient.py", line 593, in _partial_fit
    _check_partial_fit_first_call(self, classes)
  File "D:\Code_environments\venv_coralnet_py310\lib\site-packages\sklearn\utils\multiclass.py", line 368, in _check_partial_fit_first_call
    clf.classes_ = unique_labels(classes)
  File "D:\Code_environments\venv_coralnet_py310\lib\site-packages\sklearn\utils\multiclass.py", line 103, in unique_labels
    raise ValueError("Unknown label type: %s" % repr(ys))
ValueError: Unknown label type: ([UUID('115ec141-332b-4ac6-b94c-2ce178402c5f'), UUID('2acacc19-ce7d-4b9d-9b1e-cbf761c9e8c7')],)
```

However, a string representation of a UUID worked just fine. So in other words, passing the result of `uuid.uuid4()` directly won't work, but passing `str(uuid.uuid4())` would work. Hopefully that works fine (or was the intent to begin with)?

As for why passing a raw UUID got an error, I tried to look through the sklearn documentation for any constraints on label types. Two relevant pages/sections that I can point out:

1. https://scikit-learn.org/stable/modules/generated/sklearn.utils.multiclass.unique_labels.html

   > **We don’t allow:**
   > 
   > - mix of multilabel and multiclass (single label) targets
   > - mix of label indicator matrix and anything else, because there are no explicit labels)
   > - mix of label indicator matrices of different sizes
   > - mix of string and integer labels

   Note that `unique_labels()` is the last function call in the above traceback. This comment from the function suggests that strings and integers are allowed, but maybe some types that are quite different from str/int are not allowed.

2. https://scikit-learn.org/stable/glossary.html#term-target

   > **target**
   >
   > **targets**
   > 
   > The *dependent variable* in [supervised](https://scikit-learn.org/stable/glossary.html#term-supervised) (and [semisupervised](https://scikit-learn.org/stable/glossary.html#term-semisupervised)) learning, passed as [y](https://scikit-learn.org/stable/glossary.html#term-y) to an estimator’s [fit](https://scikit-learn.org/stable/glossary.html#term-fit) method. Also known as *dependent variable*, *outcome variable*, *response variable*, *ground truth* or *label*. Scikit-learn works with targets that have minimal structure: a class from a finite set, a finite real-valued number, multiple classes, or multiple numbers. See [Target Types](https://scikit-learn.org/stable/glossary.html#glossary-target-types).

   "targets that have minimal structure". So that seems to justify str/int over some arbitrary class like UUID.

Besides that, in terms of how far along this PR is: the support for str usage should be there, but no unit tests have been added yet (I just temporarily modified a couple of tests to use str instead of int to test things out, but did not commit those modifications; still deciding how I want to organize any new tests).