### PR TITLE
Accept int or str as label ID, not just int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0 (WIP)
+
+- The `train_classifier` task now accepts label IDs as either integers or strings, not just integers.
+
 ## 0.8.0
 
 - `ImageFeatures` with `valid_rowcol=False` are no longer supported for training. For now they are still supported for classification.

--- a/README.md
+++ b/README.md
@@ -242,8 +242,7 @@ message = TrainClassifierMsg(
     # The dict keys must be the same as the `key` used in the
     # extract-features task's `feature_loc`.
     # The dict values are lists of tuples of (row, column, label ID).
-    # You'll need to be tracking a mapping of integer label IDs to the
-    # labels you use.
+    # Label IDs may be either integers or strings.
     # preprocess_labels() can automatically split the data into training,
     # reference, and validation sets. However, you may also define how to
     # split it yourself; for details, see `TrainingTaskLabels` comments

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -8,7 +8,7 @@ import json
 from abc import ABC, abstractmethod
 from io import BytesIO
 from pprint import pformat
-from typing import Union
+from typing import Tuple, Union
 
 import numpy as np
 
@@ -23,7 +23,7 @@ from spacer.storage import storage_factory
 # However, more types are possible besides int and str (mainly, combinations
 # thereof).
 LabelId = Union[int, str]
-Annotation = tuple[int, int, LabelId]
+Annotation = Tuple[int, int, LabelId]
 
 
 class DataClass(ABC):  # pragma: no cover

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -259,8 +259,13 @@ class ImageFeatures(DataClass):
             PointFeatures(
                 row=itt,
                 col=itt,
-                # Generate floats that somewhat depend on the input labels.
-                data=list(hash(label) * np.random.randn(feature_dim)),
+                # Generate floats that depend on the input labels.
+                # The goal here is to strike a balance between
+                # the extremes of
+                # "mutually exclusive data for any 2 possible labels" and
+                # "data of 2 possible labels is so similar that any trained
+                # classifier is no better than random chance".
+                data=list(hash(label) + np.random.randn(feature_dim)),
             )
             for itt, label in enumerate(point_labels)
         ]

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -8,10 +8,22 @@ import json
 from abc import ABC, abstractmethod
 from io import BytesIO
 from pprint import pformat
+from typing import Union
 
 import numpy as np
 
 from spacer.storage import storage_factory
+
+
+# Implicit type aliases; revisit in Python 3.10
+# https://peps.python.org/pep-0613/
+#
+# LabelId is constrained by scikit-learn's usage of 'targets':
+# https://scikit-learn.org/stable/glossary.html#term-target
+# However, more types are possible besides int and str (mainly, combinations
+# thereof).
+LabelId = Union[int, str]
+Annotation = tuple[int, int, LabelId]
 
 
 class DataClass(ABC):  # pragma: no cover
@@ -69,9 +81,8 @@ class ImageLabels(DataClass):
     """ Contains row, col, label information for a set of images. """
 
     def __init__(self,
-                 # Data maps a feature key (or file path) to a List of
-                 # (row, col, label).
-                 data: dict[str, list[tuple[int, int, int]]]):
+                 # Data maps a feature key (or file path) to some Annotations.
+                 data: dict[str, list[Annotation]]):
         self._data = data
 
         self.label_count = sum([len(labels) for labels in data.values()])
@@ -242,12 +253,17 @@ class ImageFeatures(DataClass):
 
     @classmethod
     def make_random(cls,
-                    point_labels: list[int],
+                    point_labels: list[LabelId],
                     feature_dim: int):
-        pfs = [PointFeatures(row=itt,
-                             col=itt,
-                             data=list(label + np.random.randn(feature_dim)))
-               for itt, label in enumerate(point_labels)]
+        pfs = [
+            PointFeatures(
+                row=itt,
+                col=itt,
+                # Generate floats that somewhat depend on the input labels.
+                data=list(hash(label) * np.random.randn(feature_dim)),
+            )
+            for itt, label in enumerate(point_labels)
+        ]
 
         return ImageFeatures(point_features=pfs,
                              valid_rowcol=True,
@@ -308,7 +324,7 @@ class ValResults(DataClass):
                  scores: list[float],
                  gt: list[int],  # Using singular for backwards compatibility.
                  est: list[int],  # Using singular for backwards compatibility.
-                 classes: list[int]):
+                 classes: list[LabelId]):
 
         assert len(gt) == len(est)
         assert len(gt) == len(scores)

--- a/spacer/messages.py
+++ b/spacer/messages.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from spacer import config
-from spacer.data_classes import DataClass, ImageLabels
+from spacer.data_classes import DataClass, ImageLabels, LabelId
 
 
 class DataLocation(DataClass):
@@ -442,7 +442,7 @@ class ClassifyReturnMsg(DataClass):
                  # Scores is a list of (row, col, [scores]) tuples.
                  scores: list[tuple[int, int, list[float]]],
                  # Maps the score index to a global class id.
-                 classes: list[int],
+                 classes: list[LabelId],
                  valid_rowcol: bool):
 
         self.runtime = runtime

--- a/spacer/task_utils.py
+++ b/spacer/task_utils.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from PIL import Image
 
 from spacer import config
-from spacer.data_classes import ImageLabels
+from spacer.data_classes import ImageLabels, LabelId
 from spacer.exceptions import (
     DataLimitError, RowColumnInvalidError, TrainingLabelsError)
 from spacer.messages import TrainingTaskLabels
@@ -71,7 +71,7 @@ def preprocess_labels(
         labels_in: ImageLabels | TrainingTaskLabels,
         # If present, the passed labels are filtered so that any classes not
         # included in this set have their labels discarded.
-        accepted_classes: set[int] | None = None) -> TrainingTaskLabels:
+        accepted_classes: set[LabelId] | None = None) -> TrainingTaskLabels:
     """
     This function can be used to preprocess labels before creating a
     TrainClassifierMsg. It does:

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import random
 import unittest
 
 from PIL import Image
@@ -30,6 +31,7 @@ from spacer.tasks import \
     train_classifier, \
     classify_features, \
     classify_image
+from spacer.task_utils import preprocess_labels
 from spacer.tests.utils import cn_beta_fixture_location
 from spacer.train_utils import make_random_data, train
 from .decorators import require_test_fixtures
@@ -158,70 +160,69 @@ class TestExtractFeatures(unittest.TestCase):
 
 class TestTrainClassifier(unittest.TestCase):
 
-    def test_default(self):
+    def do_basic_run(self, class_list, clf_type):
 
         # Parameters for data generation
-        n_traindata = 160
-        n_refdata = 20
-        n_valdata = 20
+        n_data = 200
         points_per_image = 20
         feature_dim = 5
-        class_list = [1, 2]
 
         # Create training data.
         features_loc_template = DataLocation(storage_type='memory', key='')
-        train_labels = make_random_data(
-            n_traindata, class_list, points_per_image,
-            feature_dim, features_loc_template,
-        )
-        ref_labels = make_random_data(
-            n_refdata, class_list, points_per_image,
-            feature_dim, features_loc_template,
-        )
-        val_labels = make_random_data(
-            n_valdata, class_list, points_per_image,
-            feature_dim, features_loc_template,
-        )
-
-        for clf_type in config.CLASSIFIER_TYPES:
-            # Train once by calling directly so that we have a
-            # previous classifier.
-            clf, _ = train(
-                train_labels, ref_labels, features_loc_template, 1, clf_type)
-
-            previous_classifier_loc = DataLocation(storage_type='memory',
-                                                   key='pc')
-            store_classifier(previous_classifier_loc, clf)
-
-            valresult_loc = DataLocation(storage_type='memory', key='val_res')
-
-            msg = TrainClassifierMsg(
-                job_token='test',
-                trainer_name='minibatch',
-                nbr_epochs=1,
-                clf_type=clf_type,
-                labels=TrainingTaskLabels(
-                    train=train_labels,
-                    ref=ref_labels,
-                    val=val_labels,
-                ),
-                features_loc=features_loc_template,
-                previous_model_locs=[previous_classifier_loc],
-                model_loc=DataLocation(storage_type='memory', key='model'),
-                valresult_loc=valresult_loc
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
             )
-            return_msg = train_classifier(msg)
-            self.assertEqual(type(return_msg), TrainClassifierReturnMsg)
+        )
 
-            # Do some checks on ValResults
-            val_res = ValResults.load(valresult_loc)
-            self.assertEqual(type(val_res), ValResults)
-            self.assertEqual(len(val_res.gt), len(val_res.est))
-            self.assertEqual(len(val_res.gt), len(val_res.scores))
+        # Train once by calling directly so that we have a
+        # previous classifier.
+        clf, _ = train(
+            labels.train, labels.ref, features_loc_template, 1, clf_type)
 
-            self.assertEqual(
-                len(val_res.gt), val_labels.label_count,
-                msg="val_res has the correct number of labels")
+        previous_classifier_loc = DataLocation(storage_type='memory',
+                                               key='pc')
+        store_classifier(previous_classifier_loc, clf)
+
+        valresult_loc = DataLocation(storage_type='memory', key='val_res')
+
+        msg = TrainClassifierMsg(
+            job_token='test',
+            trainer_name='minibatch',
+            nbr_epochs=1,
+            clf_type=clf_type,
+            labels=labels,
+            features_loc=features_loc_template,
+            previous_model_locs=[previous_classifier_loc],
+            model_loc=DataLocation(storage_type='memory', key='model'),
+            valresult_loc=valresult_loc
+        )
+        return_msg = train_classifier(msg)
+        self.assertEqual(type(return_msg), TrainClassifierReturnMsg)
+
+        # Do some checks on ValResults
+        val_res = ValResults.load(valresult_loc)
+        self.assertEqual(type(val_res), ValResults)
+        self.assertEqual(len(val_res.gt), len(val_res.est))
+        self.assertEqual(len(val_res.gt), len(val_res.scores))
+        self.assertSetEqual(set(val_res.classes), set(class_list))
+
+        self.assertEqual(
+            len(val_res.gt), labels.val.label_count,
+            msg="val_res has the correct number of labels")
+
+    def test_lr_int_labels(self):
+        self.do_basic_run([1, 2], 'LR')
+
+    def test_mlp_int_labels(self):
+        self.do_basic_run([1, 2], 'MLP')
+
+    def test_lr_str_labels(self):
+        self.do_basic_run(['Porites', 'CCA', 'Sand'], 'LR')
+
+    def test_mlp_str_labels(self):
+        self.do_basic_run(['Porites', 'CCA', 'Sand'], 'MLP')
 
     def test_row_column_matching(self):
 
@@ -289,6 +290,40 @@ class TestTrainClassifier(unittest.TestCase):
 
 class ClassifyReturnMsgTest(unittest.TestCase):
 
+    @staticmethod
+    def _train_classifier(class_list):
+        # Parameters for data generation
+        n_data = 200
+        points_per_image = 20
+        feature_dim = 5
+
+        # Create training data.
+        features_loc_template = DataLocation(storage_type='memory', key='')
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            )
+        )
+
+        model_loc = DataLocation(storage_type='memory', key='model')
+        valresult_loc = DataLocation(storage_type='memory', key='val_res')
+
+        msg = TrainClassifierMsg(
+            job_token='test',
+            trainer_name='minibatch',
+            nbr_epochs=1,
+            clf_type='MLP',
+            labels=labels,
+            features_loc=features_loc_template,
+            previous_model_locs=[],
+            model_loc=model_loc,
+            valresult_loc=valresult_loc
+        )
+        train_classifier(msg)
+
+        return model_loc
+
     def _validate_return_msg(self, return_msg, valid_rowcol):
 
         self.assertTrue(isinstance(return_msg.runtime, float))
@@ -351,6 +386,31 @@ class TestClassifyFeatures(ClassifyReturnMsgTest):
 
         self._validate_return_msg(return_msg, True)
 
+    def do_train_and_classify(self, class_list):
+        model_loc = self._train_classifier(class_list)
+
+        feats = ImageFeatures.make_random(
+            random.choices(class_list, k=4), feature_dim=5)
+        feature_loc = DataLocation(storage_type='memory',
+                                   key='new.jpg.feats')
+        feats.store(feature_loc)
+
+        msg = ClassifyFeaturesMsg(
+            job_token='my_job',
+            feature_loc=feature_loc,
+            classifier_loc=model_loc
+        )
+
+        return_msg = classify_features(msg)
+
+        self._validate_return_msg(return_msg, True)
+
+    def test_train_and_classify_int_labels(self):
+        self.do_train_and_classify([1, 2, 3])
+
+    def test_train_and_classify_str_labels(self):
+        self.do_train_and_classify(['Porites', 'CCA', 'Sand'])
+
 
 class TestClassifyImage(ClassifyReturnMsgTest):
 
@@ -369,6 +429,28 @@ class TestClassifyImage(ClassifyReturnMsgTest):
         )
         return_msg = classify_image(msg)
         self._validate_return_msg(return_msg, True)
+
+    def do_train_and_classify(self, class_list):
+        model_loc = self._train_classifier(class_list)
+
+        msg = ClassifyImageMsg(
+            job_token='my_job',
+            extractor=DummyExtractor(feature_dim=5),
+            rowcols=[(100, 100), (200, 200)],
+            image_loc=DataLocation(storage_type='url',
+                                   key=TEST_URL),
+            classifier_loc=model_loc
+        )
+
+        return_msg = classify_image(msg)
+
+        self._validate_return_msg(return_msg, True)
+
+    def test_train_and_classify_int_labels(self):
+        self.do_train_and_classify([1, 2, 3])
+
+    def test_train_and_classify_str_labels(self):
+        self.do_train_and_classify(['Porites', 'CCA', 'Sand'])
 
 
 class TestClassifyImageCache(unittest.TestCase):
@@ -410,7 +492,7 @@ class TestClassifyImageCache(unittest.TestCase):
         self.assertLess(return_msg2.runtime, return_msg3.runtime)
 
 
-class TestBadRowcols(unittest.TestCase):
+class TestClassifyBadRowcols(unittest.TestCase):
 
     @require_test_fixtures
     def test_image_classify(self):

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -343,7 +343,9 @@ class ClassifyReturnMsgTest(unittest.TestCase):
                 self.assertIsNone(col)
 
         for class_ in return_msg.classes:
-            self.assertTrue(isinstance(class_, LabelId))
+            # Change to LabelID when on Python 3.10+ only.
+            self.assertTrue(
+                isinstance(class_, int) or isinstance(class_, str))
 
         self.assertTrue(isinstance(return_msg.valid_rowcol, bool))
 

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -4,7 +4,7 @@ from PIL import Image
 
 from spacer import config
 from spacer.data_classes import (
-    ImageFeatures, ImageLabels, PointFeatures, ValResults)
+    ImageFeatures, ImageLabels, LabelId, PointFeatures, ValResults)
 from spacer.exceptions import (
     DataLimitError, RowColumnInvalidError, RowColumnMismatchError)
 from spacer.extract_features import DummyExtractor
@@ -308,7 +308,7 @@ class ClassifyReturnMsgTest(unittest.TestCase):
                 self.assertIsNone(col)
 
         for class_ in return_msg.classes:
-            self.assertTrue(isinstance(class_, int))
+            self.assertTrue(isinstance(class_, LabelId))
 
         self.assertTrue(isinstance(return_msg.valid_rowcol, bool))
 

--- a/spacer/tests/test_train_classifier.py
+++ b/spacer/tests/test_train_classifier.py
@@ -58,12 +58,15 @@ class TestDefaultTrainerDummyData(unittest.TestCase):
             )
 
             # The way we rendered the data, accuracy is usually around 90%.
-            # Adding some margin to account for randomness.
-            # TODO: fix random seed; somehow the set above didn't work.
+            # Adding some margin to account for randomness. Due to randomizer
+            # seeding, results should be the same when re-running in the same
+            # environment, but can change when the environment changes.
+            # Results also heavily depend on the implementation of
+            # make_random_data().
             self.assertGreater(return_message.acc,
                                0.75,
-                               "Failure may be due to random generated numbers,"
-                               "re-run tests.")
+                               "Failure may be due to random generated numbers."
+                               " Consider lowering the acc threshold.")
             self.assertEqual(len(return_message.pc_accs), 2)
             self.assertEqual(len(return_message.ref_accs), num_epochs)
 

--- a/spacer/tests/test_train_utils.py
+++ b/spacer/tests/test_train_utils.py
@@ -53,13 +53,12 @@ class TestMakeRandom(unittest.TestCase):
 
 class TestTrain(unittest.TestCase):
 
-    def test_ok(self):
+    def do_basic_run(self, class_list, clf_type):
 
         n_traindata = 5
         n_refdata = 1
         points_per_image = 20
         feature_dim = 5
-        class_list = [1, 2]
         num_epochs = 4
         feature_loc = DataLocation(storage_type='memory', key='')
 
@@ -72,15 +71,26 @@ class TestTrain(unittest.TestCase):
             feature_dim, feature_loc,
         )
 
-        for clf_type in config.CLASSIFIER_TYPES:
-            clf_calibrated, ref_acc = train(
-                train_labels, ref_labels, feature_loc,
-                num_epochs, clf_type,
-            )
+        clf_calibrated, ref_acc = train(
+            train_labels, ref_labels, feature_loc,
+            num_epochs, clf_type,
+        )
 
-            self.assertEqual(
-                len(ref_acc), num_epochs,
-                msg="Sanity check: expecting one ref_acc element per epoch")
+        self.assertEqual(
+            len(ref_acc), num_epochs,
+            msg="Sanity check: expecting one ref_acc element per epoch")
+
+    def test_lr_int_labels(self):
+        self.do_basic_run([1, 2], 'LR')
+
+    def test_mlp_int_labels(self):
+        self.do_basic_run([1, 2], 'MLP')
+
+    def test_lr_str_labels(self):
+        self.do_basic_run(['Porites', 'CCA', 'Sand'], 'LR')
+
+    def test_mlp_str_labels(self):
+        self.do_basic_run(['Porites', 'CCA', 'Sand'], 'MLP')
 
     def test_mlp_hybrid_mode(self):
 

--- a/spacer/tests/test_train_utils.py
+++ b/spacer/tests/test_train_utils.py
@@ -4,7 +4,8 @@ import unittest
 import numpy as np
 
 from spacer import config
-from spacer.data_classes import ImageLabels, PointFeatures, ImageFeatures
+from spacer.data_classes import (
+    Annotation, ImageLabels, PointFeatures, ImageFeatures)
 from spacer.exceptions import RowColumnInvalidError, RowColumnMismatchError
 from spacer.messages import DataLocation
 from spacer.train_utils import (
@@ -278,10 +279,8 @@ class TestAcc(unittest.TestCase):
 
     def test_simple(self):
         self.assertEqual(calc_acc([1, 2, 3, 11], [1, 2, 1, 4]), 0.5)
-        self.assertRaises(TypeError, calc_acc, [], [])
+        self.assertRaises(ValueError, calc_acc, [], [])
         self.assertRaises(ValueError, calc_acc, [1], [2, 1])
-        self.assertRaises(TypeError, calc_acc, [1.1], [1])
-        self.assertRaises(TypeError, calc_acc, [1], [1.1])
 
 
 class TestLoadImageData(unittest.TestCase):
@@ -294,7 +293,7 @@ class TestLoadImageData(unittest.TestCase):
                                        key=cls.feat_key)
 
     def fixtures(self, in_order=True, valid_rowcol=True) \
-            -> tuple[list[tuple[int, int, int]], ImageFeatures]:
+            -> tuple[list[Annotation], ImageFeatures]:
 
         labels = [(100, 100, 1),
                   (200, 200, 2),


### PR DESCRIPTION
(Take 3, after deciding this is the next thing to merge after all)

From Mermaid Trello card:

> Since Mermaid thus far has used UUIDs, not integer IDs, for BAGFs.
> 
> CoralNet has always used integer IDs for everything in its database, so I believe that design assumption just carried over to the way that pyspacer identifies labels (classes). I couldn’t think of any reason why this would need to be an integer. The values do get passed into scikit-learn’s `MLPClassifier` and `SGDClassifier`, but the relevant methods/fields `predict()`, `predict_proba()`, and `classes_` seem to take an array of any type.
> 
> This would involve relaxing the parameter type annotations in various functions/methods such as `ImageLabels.__init__()`, `ImageLabels.unique_classes()`, `load_image_data()`, `load_batch_data()`, `evaluate_classifier()`, and `make_random_data()`. I think `make_random_data()` does actually use the parameter as an int (or at least something that’s addable to a float), but that doesn’t seem to be a necessary implementation detail. Of note, `ValResults` actually uses indices into a list of labels, rather than using the label representations themselves, so some stuff related to `ValResults` won't need changing.
> 
> I’d probably define a custom data type `LabelId` which is an alias of `Hashable`. So if we ever decide that `Hashable` isn’t quite what we wanted for label IDs, that’ll be easier to change next time.

This plan ran into a hitch though: a `uuid.UUID`, which is Hashable, got this sort of error when used for training:

```
Traceback (most recent call last):
  File "D:\CVCE\Site\pyspacer\spacer\tests\test_tasks.py", line 190, in test_default
    clf, _ = train(
  File "D:\CVCE\Site\pyspacer\spacer\train_utils.py", line 73, in train
    clf.partial_fit(x, y, classes=classes_list)
  File "D:\Code_environments\venv_coralnet_py310\lib\site-packages\sklearn\linear_model\_stochastic_gradient.py", line 848, in partial_fit
    return self._partial_fit(
  File "D:\Code_environments\venv_coralnet_py310\lib\site-packages\sklearn\linear_model\_stochastic_gradient.py", line 593, in _partial_fit
    _check_partial_fit_first_call(self, classes)
  File "D:\Code_environments\venv_coralnet_py310\lib\site-packages\sklearn\utils\multiclass.py", line 368, in _check_partial_fit_first_call
    clf.classes_ = unique_labels(classes)
  File "D:\Code_environments\venv_coralnet_py310\lib\site-packages\sklearn\utils\multiclass.py", line 103, in unique_labels
    raise ValueError("Unknown label type: %s" % repr(ys))
ValueError: Unknown label type: ([UUID('115ec141-332b-4ac6-b94c-2ce178402c5f'), UUID('2acacc19-ce7d-4b9d-9b1e-cbf761c9e8c7')],)
```

However, a string representation of a UUID worked just fine. So in other words, passing the result of `uuid.uuid4()` directly won't work, but passing `str(uuid.uuid4())` would work. Hopefully that works fine (or was the intent to begin with)?

As for why passing a raw UUID got an error, I tried to look through the sklearn documentation for any constraints on label types. Two relevant pages/sections that I can point out:

1. https://scikit-learn.org/stable/modules/generated/sklearn.utils.multiclass.unique_labels.html

   > **We don’t allow:**
   > 
   > - mix of multilabel and multiclass (single label) targets
   > - mix of label indicator matrix and anything else, because there are no explicit labels)
   > - mix of label indicator matrices of different sizes
   > - mix of string and integer labels

   Note that `unique_labels()` is the last function call in the above traceback. This comment from the function suggests that strings and integers are allowed, but maybe some types that are quite different from str/int are not allowed.

2. https://scikit-learn.org/stable/glossary.html#term-target

   > **target**
   >
   > **targets**
   > 
   > The *dependent variable* in [supervised](https://scikit-learn.org/stable/glossary.html#term-supervised) (and [semisupervised](https://scikit-learn.org/stable/glossary.html#term-semisupervised)) learning, passed as [y](https://scikit-learn.org/stable/glossary.html#term-y) to an estimator’s [fit](https://scikit-learn.org/stable/glossary.html#term-fit) method. Also known as *dependent variable*, *outcome variable*, *response variable*, *ground truth* or *label*. Scikit-learn works with targets that have minimal structure: a class from a finite set, a finite real-valued number, multiple classes, or multiple numbers. See [Target Types](https://scikit-learn.org/stable/glossary.html#glossary-target-types).

   "targets that have minimal structure". So that seems to justify str/int over some arbitrary class like UUID.