### PR TITLE
Supported Pythons: 3.8 to 3.10 -> 3.10 to 3.11

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -9,10 +9,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    # 23.04 isn't an LTS version, but ensures that Python 3.11 is available
+    runs-on: ubuntu-23.04
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10" ]
+        python-version: [ "3.10", "3.11" ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   build:
 
-    # 23.04 isn't an LTS version, but ensures that Python 3.11 is available
-    runs-on: ubuntu-23.04
+    # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#python
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [ "3.10", "3.11" ]

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-adding-configurations
-        includes:
+        include:
           - python-version: "3.10"
             requirements: "dev"
           - python-version: "3.10"
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install ${{ matrix.requirements }} dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements/${{ matrix.requirements }}.txt

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,14 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11" ]
+        # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-adding-configurations
+        includes:
+          - python-version: "3.10"
+            requirements: "dev"
+          - python-version: "3.10"
+            requirements: "min"
+          - python-version: "3.11"
+            requirements: "max"
 
     steps:
     - uses: actions/checkout@v2
@@ -24,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements/${{ matrix.requirements }}.txt
     - name: Run tests
       run: |
         python -m unittest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.9.0 (WIP)
 
+- Python 3.8 and 3.9 support have been dropped; Python 3.11 support has been added.
+
+- torch and torchvision accepted versions have been relaxed to accommodate Python 3.11. (torch==1.13.1 to torch>=1.13.1,<2.3; torchvision==0.14.1 to torchvision>=0.14.1,<0.18)
+
 - The `train_classifier` task now accepts label IDs as either integers or strings, not just integers.
 
 ## 0.8.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PySpacer (AKA spacer) provides utilities to extract features from random point
 locations in images and then train classifiers over those features.
 It is used in the vision backend of `https://github.com/coralnet/coralnet`.
 
-Spacer currently supports python >=3.8.
+Spacer currently supports Python 3.10 and 3.11.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ run the same command but append `bash` in the end.
 ### Local clone
 * Clone this repo
   * If using Windows: turn Git's `autocrlf` setting off before your initial checkout. Otherwise, pickled classifiers in `spacer/tests/fixtures` will get checked out with `\r\n` newlines, and the pickle module will fail to load them, leading to test failures. However, autocrlf should be left on when adding any new non-pickle files.
-* `pip install -r requirements.txt`
+* `pip install -r requirements/dev.txt`
 * Set up configuration
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ authors = [
 ]
 description = "Spatial image analysis with pytorch and caffe backends."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "Pillow>=10.2.0",
     "numpy>=1.19",
     "scikit-learn==1.1.3",
-    "torch==1.13.1",
-    "torchvision==0.14.1",
+    "torch>=1.13.1,<2.3",
+    "torchvision>=0.14.1,<0.18",
     "boto3",
 ]
 license = {file = "license.txt"}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,5 @@
+# Package versions recommended for developers.
+
 coverage==7.0.5
 
 # https://tqdm.github.io/releases/

--- a/requirements/max.txt
+++ b/requirements/max.txt
@@ -1,0 +1,8 @@
+# This should install pyproject.toml's maximum accepted versions.
+
+Pillow>=10.2.0
+numpy>=1.19
+scikit-learn==1.1.3
+torch>=1.13.1,<2.3
+torchvision>=0.14.1,<0.18
+boto3

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -1,0 +1,8 @@
+# This should install pyproject.toml's minimum accepted versions.
+
+Pillow==10.2.0
+numpy==1.24.1
+scikit-learn==1.1.3
+torch==1.13.1
+torchvision==0.14.1
+boto3==1.26.122

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -8,22 +8,19 @@ import json
 from abc import ABC, abstractmethod
 from io import BytesIO
 from pprint import pformat
-from typing import Tuple, Union
+from typing import TypeAlias
 
 import numpy as np
 
 from spacer.storage import storage_factory
 
 
-# Implicit type aliases; revisit in Python 3.10
-# https://peps.python.org/pep-0613/
-#
 # LabelId is constrained by scikit-learn's usage of 'targets':
 # https://scikit-learn.org/stable/glossary.html#term-target
 # However, more types are possible besides int and str (mainly, combinations
 # thereof).
-LabelId = Union[int, str]
-Annotation = Tuple[int, int, LabelId]
+LabelId: TypeAlias = int | str
+Annotation: TypeAlias = tuple[int, int, LabelId]
 
 
 class DataClass(ABC):  # pragma: no cover

--- a/spacer/storage.py
+++ b/spacer/storage.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import abc
 import os
 import pickle
-import socket
 import warnings
 from functools import lru_cache
 from http.client import IncompleteRead
@@ -61,12 +60,10 @@ class URLStorage(Storage):
             # - The initial connection; else URLError - <urlopen error timed
             #   out> is raised.
             # - A single idle period mid-response (not the entire response
-            #   time); else socket.timeout - timed out is raised
-            #   (socket.timeout is a deprecated alias of TimeoutError starting
-            #   in Python 3.10).
+            #   time); else TimeoutError - timed out is raised.
             download_response = urllib.request.urlopen(
                 url, timeout=self.TIMEOUT)
-        except (socket.timeout, URLError, ValueError) as e:
+        except (TimeoutError, URLError, ValueError) as e:
             # Besides timeouts, possible errors include:
             # ValueError: unknown url type: '<url>'
             #   - Malformed url
@@ -110,7 +107,7 @@ class URLStorage(Storage):
 
         try:
             urllib.request.urlopen(request, timeout=self.TIMEOUT)
-        except (socket.timeout, URLError):
+        except (TimeoutError, URLError):
             # Might be an unreachable domain, 404, or something else
             return False
         return True

--- a/spacer/tests/test_storage.py
+++ b/spacer/tests/test_storage.py
@@ -1,7 +1,6 @@
 import abc
 import json
 import os
-import socket
 import time
 import unittest
 import urllib.request
@@ -99,8 +98,7 @@ def raise_404(url, *args, **kwargs):
 
 
 def raise_timeout(url, *args, **kwargs):
-    # When only supporting Python 3.10+, change socket.timeout to TimeoutError
-    raise socket.timeout("timed out")
+    raise TimeoutError("timed out")
 
 
 class TestURLStorage(unittest.TestCase):

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -343,9 +343,7 @@ class ClassifyReturnMsgTest(unittest.TestCase):
                 self.assertIsNone(col)
 
         for class_ in return_msg.classes:
-            # Change to LabelID when on Python 3.10+ only.
-            self.assertTrue(
-                isinstance(class_, int) or isinstance(class_, str))
+            self.assertTrue(isinstance(class_, LabelId))
 
         self.assertTrue(isinstance(return_msg.valid_rowcol, bool))
 

--- a/spacer/train_utils.py
+++ b/spacer/train_utils.py
@@ -7,7 +7,7 @@ import random
 import string
 from collections.abc import Generator
 from logging import getLogger
-from typing import List, Tuple
+from typing import TypeAlias
 
 import numpy as np
 from sklearn.calibration import CalibratedClassifierCV
@@ -22,10 +22,8 @@ from spacer.messages import DataLocation
 logger = getLogger(__name__)
 
 
-# Implicit type alias; revisit in Python 3.10
-# https://peps.python.org/pep-0613/
-FeatureLabelPair = Tuple[np.ndarray, LabelId]
-FeatureLabelBatch = Tuple[List[np.ndarray], List[LabelId]]
+FeatureLabelPair: TypeAlias = tuple[np.ndarray, LabelId]
+FeatureLabelBatch: TypeAlias = tuple[list[np.ndarray], list[LabelId]]
 
 
 def train(train_labels: ImageLabels,


### PR DESCRIPTION
Doing this because I keep accidentally relying on Python 3.10 stuff (mainly related to type annotations), and there currently doesn't seem to be a need for 3.8/3.9 support (CoralNet and MERMAID use 3.10). And 3.11 support didn't seem like that much of a stretch.

torch and torchvision accepted versions have been relaxed to accommodate Python 3.11 (torch==1.13.1 to torch>=1.13.1,<2.3; torchvision==0.14.1 to torchvision>=0.14.1,<0.18). Hopefully that works out in GitHub's CI.

If CI passes, I'll just merge this whenever my next PR is ready to go; but in the meantime, reviews are welcome.