### PR TITLE
Enhance annotation sampling for training, v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - torch and torchvision accepted versions have been relaxed to accommodate Python 3.11. (torch==1.13.1 to torch>=1.13.1,<2.3; torchvision==0.14.1 to torchvision>=0.14.1,<0.18)
 
+- `task_utils.preprocess_labels()` now has three available modes on how to split training annotations between train, ref, and val sets. Differences between the three modes - `VECTORS`, `POINTS`, and `POINTS_STRATIFIED` - are explained in the `SplitMode` Enum's comments. Additionally, all three modes now ensure that the ordering of the given training data has no effect on which data goes into train, ref, and val.
+
 - The `train_classifier` task now accepts label IDs as either integers or strings, not just integers.
 
 ## 0.8.0

--- a/README.md
+++ b/README.md
@@ -204,12 +204,21 @@ from spacer.messages import TrainingTaskLabels
 from spacer.task_utils import preprocess_labels
 
 # 1
-labels = preprocess_labels(ImageLabels(...), ...)
+labels = preprocess_labels(
+    ImageLabels("see previous code block for example args to ImageLabels..."),
+    "optional args to preprocess_labels()...",
+)
 # 2
 labels = TrainingTaskLabels(
-    train=ImageLabels(...), ref=ImageLabels(...), val=ImageLabels(...))
+    train=ImageLabels(...),
+    ref=ImageLabels(...),
+    val=ImageLabels(...),
+)
 # 3
-labels = preprocess_labels(TrainingTaskLabels(...), ...)
+labels = preprocess_labels(
+    TrainingTaskLabels("args like the previous example..."),
+    "optional args to preprocess_labels()...",
+)
 ```
 
 Once you have a TrainingTaskLabels instance, pass that and the other required arguments to TrainClassifierMsg, and then pass that message to `train_classifier()`, which produces:

--- a/README.md
+++ b/README.md
@@ -190,10 +190,13 @@ image_labels = ImageLabels({
 
 The `labels` argument of `TrainClassifierMsg` expects an instance of `data_classes.TrainingTaskLabels`. There are a few ways to create this:
 
-1. Pass a single ImageLabels instance to the `task_utils.preprocess_labels()` function. preprocess_labels() then decides how to split up your labels into train, ref, and val (while doing error checks in the meantime), and creates a TrainingTaskLabels instance from there.
-2. Pass three ImageLabels instances to the TrainingTaskLabels constructor: one instance for each of train, ref, and val.
-3. Do method 1, but also specify the `accepted_classes` argument to preprocess_labels(); this makes the function filter out any labels that aren't in the desired set of classes.
-4. Do method 2, but also pass the TrainingTaskLabels through preprocess_labels(). This allows you to use the error-checking and accepted_classes parts of preprocess_labels(), and the train/ref/val split you defined will remain intact.
+1. Pass a single ImageLabels instance to the `task_utils.preprocess_labels()` function. preprocess_labels() will:
+   - Split up your labels into train, ref, and val sets; optional arguments are available to control how the split is done.
+   - Do error checks.
+   - Optionally filter out unwanted classes, if you specified the `accepted_classes` argument.
+   - Return a TrainingTaskLabels instance.
+2. Create your own TrainingTaskLabels instance by passing three ImageLabels instances into the constructor: one ImageLabels for each of train, ref, and val. This lets you define your own arbitrary train/ref/val split.
+3. Do method 2, but then pass your TrainingTaskLabels instance through preprocess_labels(). This allows you to use just the error-checking and class-filtering parts of preprocess_labels().
 
 ```python
 from spacer.data_classes import ImageLabels
@@ -201,17 +204,15 @@ from spacer.messages import TrainingTaskLabels
 from spacer.task_utils import preprocess_labels
 
 # 1
-labels = preprocess_labels(ImageLabels(...))
+labels = preprocess_labels(ImageLabels(...), ...)
 # 2
 labels = TrainingTaskLabels(
     train=ImageLabels(...), ref=ImageLabels(...), val=ImageLabels(...))
 # 3
-labels = preprocess_labels(ImageLabels(...), accepted_classes={...})
-# 4
-labels = preprocess_labels(TrainingTaskLabels(...), accepted_classes={...})
+labels = preprocess_labels(TrainingTaskLabels(...), ...)
 ```
 
-So, pass that and the other required arguments to TrainClassifierMsg, and then pass that message to `train_classifier()`, which produces:
+Once you have a TrainingTaskLabels instance, pass that and the other required arguments to TrainClassifierMsg, and then pass that message to `train_classifier()`, which produces:
 
 - A classifier as an `sklearn.calibration.CalibratedClassifierCV` instance, stored in a pickle (.pkl) file. spacer's `storage.load_classifier()` function can help with loading classifiers that were created in older scikit-learn versions. 
 - Classifier evaluation results as a JSON file.

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -6,6 +6,7 @@ python-native data-structures such that it can be stored.
 from __future__ import annotations
 import json
 from abc import ABC, abstractmethod
+from collections import Counter
 from io import BytesIO
 from pprint import pformat
 from typing import TypeAlias
@@ -82,13 +83,18 @@ class ImageLabels(DataClass):
                  data: dict[str, list[Annotation]]):
         self._data = data
 
-        self.label_count = sum([len(labels) for labels in data.values()])
+        self.label_count_per_class = Counter()
+        for single_image_annotations in data.values():
+            labels = [label for (row, col, label) in single_image_annotations]
+            self.label_count_per_class.update(labels)
 
-        self.classes_set = set()
-        for single_image_labels in data.values():
-            single_image_classes = set(
-                label for (row, col, label) in single_image_labels)
-            self.classes_set |= single_image_classes
+    @property
+    def classes_set(self):
+        return set(self.label_count_per_class.keys())
+
+    @property
+    def label_count(self):
+        return self.label_count_per_class.total()
 
     @classmethod
     def example(cls):

--- a/spacer/task_utils.py
+++ b/spacer/task_utils.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
+from collections import defaultdict
+from enum import Enum
 from logging import getLogger
+import random
 
 from PIL import Image
+from sklearn.model_selection import train_test_split
 
 from spacer import config
 from spacer.data_classes import ImageLabels, LabelId
@@ -61,22 +65,247 @@ def check_extract_inputs(image: Image,
                 f" valid range of 0-{im_width - 1}.")
 
 
+class SplitMode(Enum):
+    """
+    How to split annotations between train, ref, and val sets.
+    """
+    # Each feature vector's points all go into train, or all go into ref, or
+    # all go into val.
+    #
+    # The rationale behind this mode is to have greater separation between
+    # training data and evaluation data, whether it's during the calibration
+    # process (train vs. ref) or during evaluation of the final classifier
+    # (train vs. val).
+    # Here we assume the imagery is 'more different' when going across feature
+    # vectors, as opposed to staying within the same feature vector. When
+    # training and evaluation data are 'more different', the result is more
+    # useful.
+    # Thus, this mode can improve usefulness of calibration, and rigor of the
+    # evaluation results.
+    # However, the annotation count may not end up precisely balanced
+    # between train/ref/val as desired, particularly when the feature vector
+    # size is comparable to the set size. For example, if each feature vector
+    # has 100 points, and the target ref-set size is 450, then the best we can
+    # do is giving the ref set either 400 or 500 points.
+    VECTORS = 'vectors'
+    # The split is done on an individual point basis, so a single
+    # feature vector may be split across train/ref/val.
+    #
+    # This allows the annotation count to be more precisely balanced
+    # between train/ref/val.
+    # However, there may be concerns that the imagery going into each set is
+    # too similar, particularly when points are densely distributed within
+    # each image.
+    POINTS = 'points'
+    # Stratified sampling by class: an A%/B%/C% train/ref/val split means
+    # an A%/B%/C% split of each class.
+    # The split is done on an individual point basis.
+    #
+    # The POINTS mode's results should already be approximately stratified due
+    # to the annotations being shuffled. However, POINTS_STRATIFIED makes the
+    # stratification more guaranteed. This can be useful because it makes the
+    # final number of unique classes more consistent.
+    #
+    # Stratification checks that the number of annotations in each
+    # set isn't less than the number of unique classes.
+    # However, each set is NOT guaranteed to have at least 1 of each class.
+    # If stratification is calculated such that a set would get <0.5
+    # annotations of a class, then that set gets 0 of that class.
+    POINTS_STRATIFIED = 'points_stratified'
+
+
+def split_labels(
+    labels_in: ImageLabels,
+    # Reference set's max ratio (also capped by
+    # TRAINING_BATCH_LABEL_COUNT) and validation set's ratio.
+    # Remaining annotations go to the training set.
+    # Example: (0.5, 0.15) for a 5% ref / 15% val / 80% train split.
+    split_ratios: tuple[float, float],
+    split_mode: SplitMode,
+) -> TrainingTaskLabels:
+    """
+    Split annotation data into training, reference, and validation sets.
+    """
+
+    # Determine train/ref/val annotation count goals.
+    # Note that these aren't necessarily going to be the final counts for
+    # training.
+    # If class filtering occurs after this function call, then the counts
+    # will change.
+    ref_max_ratio, val_ratio = split_ratios
+    ref_goal_size = min(
+        round(labels_in.label_count * ref_max_ratio),
+        config.TRAINING_BATCH_LABEL_COUNT)
+    val_goal_size = round(labels_in.label_count * val_ratio)
+    train_goal_size = (
+        labels_in.label_count - ref_goal_size - val_goal_size)
+
+    # Preempt set-size ValueErrors that would be raised from
+    # train_test_split().
+    # TrainingLabelErrors are more specific and thus should be nicer for
+    # error handling.
+
+    if split_mode == SplitMode.POINTS_STRATIFIED:
+        # Stratified by class
+        set_minimum_size = len(labels_in.classes_set)
+        explanation = (
+            f"Each set's size must not be less than the number of classes"
+            f" ({set_minimum_size}) to work with train_test_split().")
+    else:
+        set_minimum_size = 1
+        explanation = "Each set must be non-empty."
+    if ref_goal_size < set_minimum_size \
+            or val_goal_size < set_minimum_size \
+            or train_goal_size < set_minimum_size:
+        raise TrainingLabelsError(
+            f"Not enough annotations to populate train/ref/val sets."
+            f" Split was calculated as"
+            f" {train_goal_size}/{ref_goal_size}/{val_goal_size}."
+            f" {explanation}"
+        )
+
+    if split_mode == SplitMode.VECTORS:
+
+        # We don't use train_test_split() in this case because:
+        # 1) train_test_split() doesn't seem to be able to split annotations
+        #    accurately when splitting must be done at the feature vector
+        #    level, since each vector may have different annotation counts.
+        # 2) the main benefit of train_test_split() is stratification, but
+        #    we're not doing that in this case anyway.
+
+        image_keys = labels_in.image_keys
+        random.seed(0)
+        random.shuffle(image_keys)
+        # Use a generator so we can continue iterating over the image keys
+        # across multiple loops.
+        image_key_generator = (key for key in image_keys)
+
+        train_labels = dict()
+        ref_labels = dict()
+        val_labels = dict()
+
+        for labels, goal_size in [
+            (val_labels, val_goal_size),
+            (ref_labels, ref_goal_size),
+            (train_labels, train_goal_size),
+        ]:
+            # Add annotations to the set until the goal size is met/exceeded,
+            # or until all annotations are added.
+            # If the goal's exceeded, no annotations are taken back. So, since
+            # the order the sets are populated is val-ref-train, val and ref
+            # will either meet or exceed the goal sizes, while train will
+            # either meet or fall short of the goal size.
+            num_annotations = 0
+            while num_annotations < goal_size:
+                try:
+                    key = next(image_key_generator)
+                except StopIteration:
+                    break
+                labels[key] = labels_in[key]
+                num_annotations += len(labels_in[key])
+
+        return TrainingTaskLabels(
+            train=ImageLabels(train_labels),
+            ref=ImageLabels(ref_labels),
+            val=ImageLabels(val_labels),
+        )
+
+    # From here on out, we have either SplitMode.POINTS or
+    # SplitMode.POINTS_STRATIFIED, meaning we'll add annotations to the three
+    # sets on an individual-point basis.
+
+    train_data = defaultdict(list)
+    ref_data = defaultdict(list)
+    val_data = defaultdict(list)
+
+    # Map integer indices to image keys.
+    # This is just a list, and the 'lookup keys' are the list indices.
+    #
+    # We want this so we have smaller identifiers for each image
+    # (int instead of an arbitrary string)
+    # to use in the potentially very long, RAM-consuming lists below.
+    image_lookup = labels_in.image_keys
+    # Flat lists of annotation identifiers (image index +
+    # annotation-in-image index) and labels.
+    annotation_indices_flat = []
+    labels_flat = []
+
+    for image_index, image_key in enumerate(image_lookup):
+        for annotation_index, annotation in enumerate(labels_in[image_key]):
+            _row, _column, label = annotation
+            annotation_indices_flat.append((image_index, annotation_index))
+            labels_flat.append(label)
+
+    # Leave the split to scikit-learn. It can only split a set into two,
+    # so we first make it do a train+ref / val split, then a train / ref
+    # split.
+    # See SplitMode for details on stratification.
+
+    train_ref_indices, val_indices = train_test_split(
+        annotation_indices_flat,
+        test_size=val_goal_size, random_state=0, shuffle=True,
+        stratify=(
+            labels_flat if split_mode == SplitMode.POINTS_STRATIFIED
+            else None),
+    )
+
+    annotation_indices_flat_reverse_lookup = {
+        annotation_index_pair: list_index
+        for list_index, annotation_index_pair
+        in enumerate(annotation_indices_flat)
+    }
+    train_ref_labels_flat = []
+    for annotation_index_pair in train_ref_indices:
+        index_into_all_annotations = \
+            annotation_indices_flat_reverse_lookup[annotation_index_pair]
+        train_ref_labels_flat.append(labels_flat[index_into_all_annotations])
+
+    train_indices, ref_indices = train_test_split(
+        train_ref_indices,
+        test_size=ref_goal_size, random_state=0, shuffle=True,
+        stratify=(
+            train_ref_labels_flat if split_mode == SplitMode.POINTS_STRATIFIED
+            else None),
+    )
+
+    for set_indices, set_data in [
+        (train_indices, train_data),
+        (ref_indices, ref_data),
+        (val_indices, val_data),
+    ]:
+        for image_index, annotation_index in set_indices:
+            image_key = image_lookup[image_index]
+            set_data[image_key].append(
+                labels_in[image_key][annotation_index])
+
+    return TrainingTaskLabels(
+        train=ImageLabels(train_data),
+        ref=ImageLabels(ref_data),
+        val=ImageLabels(val_data),
+    )
+
+
 def preprocess_labels(
-        # Training labels (annotations); two acceptable formats:
-        #
-        # 1) An ImageLabels instance, which this function decides how to
-        # split up into training, reference, and validation sets.
-        # 2) A dict which has keys 'train', 'ref', and 'val',
-        # each mapping to a separate ImageLabels instance.
-        labels_in: ImageLabels | TrainingTaskLabels,
-        # If present, the passed labels are filtered so that any classes not
-        # included in this set have their labels discarded.
-        accepted_classes: set[LabelId] | None = None) -> TrainingTaskLabels:
+    # Training labels (annotations); two acceptable formats:
+    #
+    # 1) An ImageLabels instance, which this function decides how to
+    # split up into training, reference, and validation sets.
+    # 2) A dict which has keys 'train', 'ref', and 'val',
+    # each mapping to a separate ImageLabels instance.
+    labels_in: ImageLabels | TrainingTaskLabels,
+    # If present, the passed labels are filtered so that any classes not
+    # included in this set have their labels discarded.
+    accepted_classes: set[LabelId] | None = None,
+    # See split_labels().
+    split_ratios: tuple[float, float] = (0.1, 0.1),
+    # See split_labels().
+    split_mode: SplitMode = SplitMode.VECTORS,
+) -> TrainingTaskLabels:
     """
     This function can be used to preprocess labels before creating a
     TrainClassifierMsg. It does:
     1) Splitting of labels into train/ref/val, if not already done
-    2) Filtering of labels by valid_classes, if that arg is specified
+    2) Filtering of labels by accepted_classes, if that arg is specified
     3) Error checks
 
     This is also called by pyspacer after receiving a TrainClassifierMsg
@@ -84,56 +313,46 @@ def preprocess_labels(
     """
 
     if isinstance(labels_in, TrainingTaskLabels):
+
         # The caller has decided how to split the data into
         # training, reference, and validation sets.
+
         labels = labels_in
+
+        if accepted_classes:
+            for set_name in ['train', 'ref', 'val']:
+                labels[set_name] = \
+                    labels[set_name].filter_classes(accepted_classes)
+
     else:
-        # Split data into training, reference, and validation sets.
-        #
-        # Arbitrarily, validation gets 10%, reference gets
-        # min(10%, TRAINING_BATCH_LABEL_COUNT), training gets the rest.
-        # This is imprecise because it's split on the image level, not the
-        # label level, and images can have different numbers of labels.
-        #
-        # The split is done in a way which guarantees that all 3 sets are
-        # non-empty if there are at least 3 images.
-        if len(labels_in) < 3:
-            raise TrainingLabelsError(
-                f"The training data has {len(labels_in)} image(s),"
-                f" but need at least 3 to populate train/ref/val sets.")
 
-        train_data = dict()
-        ref_data = dict()
-        val_data = dict()
-        ref_label_count = 0
-        ref_done = False
+        # The caller is leaving the split to pyspacer.
 
-        for image_index, image_key in enumerate(labels_in.image_keys):
-            this_image_labels = labels_in[image_key]
+        pre_split_labels = labels_in
 
-            if image_index % 10 == 0:
-                # 1st, 11th, 21st, etc. images go in val.
-                val_data[image_key] = this_image_labels
-            elif not ref_done and image_index % 10 == 1:
-                # 2nd, 12th, 22nd, etc. images go in ref, if ref still
-                # has room within the batch size; else, go in train.
-                if (ref_label_count + len(this_image_labels)
-                        <= config.TRAINING_BATCH_LABEL_COUNT):
-                    ref_data[image_key] = this_image_labels
-                    ref_label_count += len(this_image_labels)
-                else:
-                    # ref would go over the batch size if it added this
-                    # image.
-                    train_data[image_key] = this_image_labels
-                    ref_done = True
-            else:
-                # The rest go in train.
-                train_data[image_key] = this_image_labels
+        if accepted_classes:
+            pre_split_labels = pre_split_labels.filter_classes(
+                accepted_classes)
 
-        labels = TrainingTaskLabels(
-            train=ImageLabels(train_data),
-            ref=ImageLabels(ref_data),
-            val=ImageLabels(val_data),
+        if split_mode == SplitMode.POINTS_STRATIFIED:
+
+            # train_test_split() will want each class to have at least as many
+            # annotations as sets (even though it doesn't guarantee what each
+            # set ends up with).
+            # Otherwise it'll raise an error. So, filter out the rare classes
+            # first.
+            common_enough_classes = [
+                label
+                for label, count in labels_in.label_count_per_class.items()
+                if count >= 3]
+            if len(common_enough_classes) != len(labels_in.classes_set):
+                pre_split_labels = pre_split_labels.filter_classes(
+                    common_enough_classes)
+
+        labels = split_labels(
+            pre_split_labels,
+            split_ratios=split_ratios,
+            split_mode=split_mode,
         )
 
     # Identify classes common to both train and ref.
@@ -141,22 +360,21 @@ def preprocess_labels(
     ref_classes = labels.ref.classes_set
     train_ref_classes = train_classes.intersection(ref_classes)
 
-    # Further filter the classes if this arg was specified.
-    if accepted_classes:
-        classes_filter = \
-            train_ref_classes.intersection(accepted_classes)
-    else:
-        classes_filter = train_ref_classes
-
-    if len(classes_filter) <= 1:
+    if len(train_ref_classes) <= 1:
         raise TrainingLabelsError(
             f"Need multiple classes to do training."
             f" After preprocessing training data, there are"
-            f" {len(classes_filter)} class(es) left.")
+            f" {len(train_ref_classes)} class(es) left.")
 
     for set_name in ['train', 'ref', 'val']:
-        labels[set_name] = \
-            labels[set_name].filter_classes(classes_filter)
+        if not labels[set_name].classes_set.issubset(train_ref_classes):
+            # The classifier can only learn about classes which are in
+            # both train and ref, so if a class is missing from one (or both)
+            # of train or ref, we discard that class's annotations.
+            # Note that this may change the annotation-count balance between
+            # train / ref / val.
+            labels[set_name] = \
+                labels[set_name].filter_classes(train_ref_classes)
 
         if len(labels[set_name]) == 0:
             raise TrainingLabelsError(

--- a/spacer/task_utils.py
+++ b/spacer/task_utils.py
@@ -69,27 +69,37 @@ class SplitMode(Enum):
     """
     How to split annotations between train, ref, and val sets.
     """
+
     # Each feature vector's points all go into train, or all go into ref, or
     # all go into val.
     #
-    # The rationale behind this mode is to have greater separation between
-    # training data and evaluation data, whether it's during the calibration
-    # process (train vs. ref) or during evaluation of the final classifier
-    # (train vs. val).
-    # Here we assume the imagery is 'more different' when going across feature
-    # vectors, as opposed to staying within the same feature vector. When
-    # training and evaluation data are 'more different', the result is more
-    # useful.
-    # Thus, this mode can improve usefulness of calibration, and rigor of the
-    # evaluation results.
+    # This mode is based on a few assumptions:
+    # 1) Each feature vector to be used as training data represents one image.
+    # 2) The imagery around a particular point is more similar to the imagery
+    #    around another point if those two points are from the same image, as
+    #    opposed to being from different images.
+    #    Therefore, a classifier trained on points of image A is expected to
+    #    have better-or-equal accuracy on other points of image A, compared to
+    #    its accuracy on points of image B.
+    # 3) Real-world usage of classifiers involves classifying 'new' images
+    #    which the classifier has not been trained on.
+    #
+    # Thus, this mode can help ensure real-world applicability of
+    # classifiers, in terms of usefulness of calibration (which depends on the
+    # differences between train and ref), and rigor of the evaluation results
+    # (which depends on the differences between train and val).
+    #
     # However, the annotation count may not end up precisely balanced
     # between train/ref/val as desired, particularly when the feature vector
     # size is comparable to the set size. For example, if each feature vector
     # has 100 points, and the target ref-set size is 450, then the best we can
     # do is giving the ref set either 400 or 500 points.
     VECTORS = 'vectors'
+
     # The split is done on an individual point basis, so a single
-    # feature vector may be split across train/ref/val.
+    # feature vector may be split across train/ref/val. For example, a
+    # feature vector with 20 point-features may have 16 points going to train,
+    # 2 going to ref, and 2 going to val.
     #
     # This allows the annotation count to be more precisely balanced
     # between train/ref/val.
@@ -97,6 +107,7 @@ class SplitMode(Enum):
     # too similar, particularly when points are densely distributed within
     # each image.
     POINTS = 'points'
+
     # Stratified sampling by class: an A%/B%/C% train/ref/val split means
     # an A%/B%/C% split of each class.
     # The split is done on an individual point basis.

--- a/spacer/tests/test_task_utils.py
+++ b/spacer/tests/test_task_utils.py
@@ -1,10 +1,12 @@
+import random
 import unittest
 
 from PIL import Image
 
 from spacer.exceptions import RowColumnInvalidError, TrainingLabelsError
 from spacer.messages import DataLocation, ImageLabels, TrainingTaskLabels
-from spacer.task_utils import check_extract_inputs, preprocess_labels
+from spacer.task_utils import (
+    check_extract_inputs, preprocess_labels, SplitMode)
 from spacer.train_utils import make_random_data
 
 
@@ -59,7 +61,7 @@ class TestRowColChecks(unittest.TestCase):
             " valid range of 0-99.")
 
 
-class TestPreprocessLabels(unittest.TestCase):
+class TestSplitLabels(unittest.TestCase):
 
     def test_train_ref_val_split(self):
         """
@@ -77,9 +79,9 @@ class TestPreprocessLabels(unittest.TestCase):
         ))
 
         # 80% 10% 10%
-        self.assertEqual(len(labels['train']), 16)
-        self.assertEqual(len(labels['ref']), 2)
-        self.assertEqual(len(labels['val']), 2)
+        self.assertEqual(labels['train'].label_count, 160)
+        self.assertEqual(labels['ref'].label_count, 20)
+        self.assertEqual(labels['val'].label_count, 20)
 
     def test_train_ref_val_split_large(self):
         """
@@ -101,27 +103,334 @@ class TestPreprocessLabels(unittest.TestCase):
         ))
 
         # 80%+ (capped to 5000 points) 10%
-        self.assertEqual(len(labels['train']), 49)
-        self.assertEqual(len(labels['ref']), 5)
-        self.assertEqual(len(labels['val']), 6)
+        self.assertEqual(labels['train'].label_count, 49000)
+        self.assertEqual(labels['ref'].label_count, 5000)
+        self.assertEqual(labels['val'].label_count, 6000)
 
-    def test_too_few_images(self):
-        n_data = 2
-        points_per_image = 5
+    def test_custom_split_ratio(self):
+        n_data = 10
+        points_per_image = 10
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+               n_data, class_list, points_per_image,
+               feature_dim, features_loc_template,
+            ),
+            split_ratios=(0.2, 0.3),
+        )
+
+        # 50% 20% 30%
+        self.assertEqual(labels['train'].label_count, 50)
+        self.assertEqual(labels['ref'].label_count, 20)
+        self.assertEqual(labels['val'].label_count, 30)
+
+    def test_vectors_imprecise_split(self):
+        n_data = 10
+        points_per_image = 10
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            split_ratios=(0.26, 0.24),
+            split_mode=SplitMode.VECTORS,
+        )
+
+        # The rest, 26% rounded up to nearest vector, 24% rounded up to
+        # nearest vector
+        self.assertEqual(labels['train'].label_count, 40)
+        self.assertEqual(labels['ref'].label_count, 30)
+        self.assertEqual(labels['val'].label_count, 30)
+
+    def test_points_precise_split(self):
+        n_data = 10
+        points_per_image = 10
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            split_ratios=(0.26, 0.24),
+            split_mode=SplitMode.POINTS,
+        )
+
+        # 50%, 26%, 24%; exact despite having 10 points per feature vector
+        self.assertEqual(labels['train'].label_count, 50)
+        self.assertEqual(labels['ref'].label_count, 26)
+        self.assertEqual(labels['val'].label_count, 24)
+
+    def test_vectors_keep_vectors_together(self):
+        n_data = 10
+        points_per_image = 10
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            split_ratios=(0.2, 0.2),
+            split_mode=SplitMode.VECTORS,
+        )
+
+        # If each vector is entirely in one set, then these should be the
+        # number of vectors in each set.
+        self.assertEqual(len(labels['train'].image_keys), 6)
+        self.assertEqual(len(labels['ref'].image_keys), 2)
+        self.assertEqual(len(labels['val'].image_keys), 2)
+
+    def test_points_dont_keep_vectors_together(self):
+        n_data = 10
+        points_per_image = 10
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            split_ratios=(0.2, 0.2),
+            split_mode=SplitMode.POINTS,
+        )
+
+        # It should be exceedingly unlikely for every vector to have all
+        # 10 of its points in one set. That is, we expect at least one
+        # image key to appear in two or more sets.
+        self.assertGreater(
+            len(labels['train'].image_keys)
+            + len(labels['ref'].image_keys)
+            + len(labels['val'].image_keys),
+            10,
+        )
+
+    def test_points_just_enough_annotations(self):
+        n_data = 1
+        points_per_image = 100
+        feature_dim = 5
+        class_list = [1, 2]
+        features_loc_template = DataLocation(storage_type='memory', key='')
+
+        labels = preprocess_labels(
+            make_random_data(
+                n_data, class_list, points_per_image,
+                feature_dim, features_loc_template,
+            ),
+            # There is another error concerning not having 2+ unique
+            # classes in the ref set which we don't want to test here, so
+            # we make the ref set large enough to generally avoid that.
+            # (25 random points drawn from [1, 2] probably aren't going
+            # to be all 1, or all 2.)
+            split_ratios=(0.25, 0.0051),
+            split_mode=SplitMode.POINTS,
+        )
+        self.assertEqual(labels['train'].label_count, 74)
+        self.assertEqual(labels['ref'].label_count, 25)
+        self.assertEqual(labels['val'].label_count, 1)
+
+    def test_points_too_few_annotations(self):
+        n_data = 1
+        points_per_image = 100
         feature_dim = 5
         class_list = [1, 2]
         features_loc_template = DataLocation(storage_type='memory', key='')
 
         with self.assertRaises(TrainingLabelsError) as cm:
-            preprocess_labels(make_random_data(
-                n_data, class_list, points_per_image,
-                feature_dim, features_loc_template,
-            ))
+            preprocess_labels(
+                make_random_data(
+                    n_data, class_list, points_per_image,
+                    feature_dim, features_loc_template,
+                ),
+                split_ratios=(0.25, 0.0049),
+                split_mode=SplitMode.POINTS,
+            )
         self.assertEqual(
             str(cm.exception),
-            "The training data has 2 image(s), but need at least 3"
-            " to populate train/ref/val sets.")
+            f"Not enough annotations to populate train/ref/val sets."
+            f" Split was calculated as 75/25/0."
+            f" Each set must be non-empty.")
 
+    def test_points_stratified_just_enough_annotations(self):
+        labels = preprocess_labels(
+            # classes [1, 2, 3], 25 annotations
+            ImageLabels({
+                '1': [*[(n, n, 1) for n in range(0, 9)],
+                      *[(n, n, 2) for n in range(100, 108)],
+                      *[(n, n, 3) for n in range(200, 208)]],
+            }),
+            split_ratios=(0.101, 0.2),
+            split_mode=SplitMode.POINTS_STRATIFIED,
+        )
+        self.assertEqual(labels['train'].label_count, 17)
+        self.assertEqual(labels['ref'].label_count, 3)
+        self.assertEqual(labels['val'].label_count, 5)
+
+    def test_points_stratified_too_few_annotations(self):
+        with self.assertRaises(TrainingLabelsError) as cm:
+            preprocess_labels(
+                # classes [1, 2, 3], 25 annotations
+                ImageLabels({
+                    '1': [*[(n, n, 1) for n in range(0, 9)],
+                          *[(n, n, 2) for n in range(100, 108)],
+                          *[(n, n, 3) for n in range(200, 208)]],
+                }),
+                split_ratios=(0.099, 0.2),
+                split_mode=SplitMode.POINTS_STRATIFIED,
+            )
+        self.assertEqual(
+            str(cm.exception),
+            f"Not enough annotations to populate train/ref/val sets."
+            f" Split was calculated as 18/2/5."
+            f" Each set's size must not be less than the number of classes"
+            f" (3) to work with train_test_split().")
+
+    @staticmethod
+    def count_of_label(annotations: ImageLabels, label: int):
+        return len([
+            anno_label for row, column, anno_label in annotations
+            if anno_label == label
+        ])
+
+    def test_stratify_by_classes(self):
+        labels = preprocess_labels(
+            ImageLabels({
+                # Annotations per class: 60, 20, 10.
+                # The 60 are split between 2 groups of 50/10 so things aren't
+                # completely in order.
+                '1': [*[(n, n, 1) for n in range(0, 50)],
+                      *[(n, n, 2) for n in range(100, 120)],
+                      *[(n, n, 3) for n in range(200, 210)],
+                      *[(n, n, 1) for n in range(400, 410)]],
+            }),
+            split_mode=SplitMode.POINTS_STRATIFIED,
+        )
+
+        self.assertEqual(
+            self.count_of_label(labels.train['1'], 1), 48)
+        self.assertEqual(
+            self.count_of_label(labels.ref['1'], 1), 6)
+        self.assertEqual(
+            self.count_of_label(labels.val['1'], 1), 6)
+
+        self.assertEqual(
+            self.count_of_label(labels.train['1'], 2), 16)
+        self.assertEqual(
+            self.count_of_label(labels.ref['1'], 2), 2)
+        self.assertEqual(
+            self.count_of_label(labels.val['1'], 2), 2)
+
+        self.assertEqual(
+            self.count_of_label(labels.train['1'], 3), 8)
+        self.assertEqual(
+            self.count_of_label(labels.ref['1'], 3), 1)
+        self.assertEqual(
+            self.count_of_label(labels.val['1'], 3), 1)
+
+    def test_stratify_with_many_uncommon_classes(self):
+        # 10 of each of 100 classes.
+        labels_data = []
+        for class_number in range(1, 100+1):
+            labels_data.extend([
+                (coord, coord, class_number)
+                for coord in range(class_number*10, class_number*10+10)
+            ])
+        # Pre-shuffle to ensure stratification doesn't rely on the ordering
+        # in some way.
+        random.shuffle(labels_data)
+        labels = preprocess_labels(
+            ImageLabels({
+                '1': labels_data,
+            }),
+            split_mode=SplitMode.POINTS_STRATIFIED,
+        )
+
+        for class_number in range(1, 100+1):
+            self.assertEqual(
+                self.count_of_label(labels.train['1'], class_number), 8,
+                msg=f"Class {class_number} should have 8 instances in train",
+            )
+            self.assertEqual(
+                self.count_of_label(labels.ref['1'], class_number), 1,
+                msg=f"Class {class_number} should have 1 instance in ref",
+            )
+            self.assertEqual(
+                self.count_of_label(labels.val['1'], class_number), 1,
+                msg=f"Class {class_number} should have 1 instance in val",
+            )
+
+    def test_stratify_with_too_rare_classes(self):
+        """
+        Classes with less than 3 annotations shouldn't cause issues
+        for stratified splitting.
+        We expect them to get excluded before splitting.
+        """
+        labels = preprocess_labels(
+            ImageLabels({
+                '1': [*[(n, n, 1) for n in range(0, 50)],
+                      *[(n, n, 2) for n in range(100, 103)],
+                      *[(n, n, 3) for n in range(200, 202)],
+                      *[(n, n, 4) for n in range(300, 301)],
+                      *[(n, n, 5) for n in range(400, 410)]],
+            }),
+            # Ensure the filtering by train+ref doesn't exclude anything,
+            # by giving ref a high ratio of 40%.
+            split_ratios=(0.4, 0.1),
+            split_mode=SplitMode.POINTS_STRATIFIED,
+        )
+
+        included_classes = labels.train.classes_set.union(
+            labels.ref.classes_set, labels.val.classes_set
+        )
+        self.assertSetEqual(
+            {1, 2, 5}, included_classes,
+            msg="Classes 3 and 4 should be excluded")
+
+    def test_do_not_stratify(self):
+        # 10 of each of 100 classes.
+        labels_data = []
+        for class_number in range(1, 100+1):
+            labels_data.extend([
+                (coord, coord, class_number)
+                for coord in range(class_number*10, class_number*10+10)
+            ])
+        # Pre-shuffle to ensure the split doesn't rely on the ordering
+        # in some way.
+        random.shuffle(labels_data)
+        labels = preprocess_labels(
+            ImageLabels({
+                '1': labels_data,
+            }),
+            split_mode=SplitMode.POINTS,
+        )
+
+        booleans = [
+            self.count_of_label(labels.train['1'], class_number) == 8
+            for class_number in range(1, 100+1)
+        ]
+        self.assertFalse(
+            all(booleans),
+            msg="The chances of perfect stratification without having"
+                " stratification on should be basically zero")
+
+
+class TestPreprocessLabels(unittest.TestCase):
+    """
+    Testing the rest of preprocess_labels() besides splitting.
+    """
     def test_train_ref_1_common_class(self):
         points_per_image = 20
         feature_dim = 5


### PR DESCRIPTION
Newer version of PR #84. The difference is that this PR has gone on top of the merges of 95 and 96, resolving any conflicts. This is a new PR because I wanted to leave the old `training-annotation-sampling` branch intact, in case it's still being used for some tests right this moment.

This PR is ready for review, and is the next thing I'm looking to finally merge.

Per the updated CHANGELOG:

> `task_utils.preprocess_labels()` now has three available modes on how to split training annotations between train, ref, and val sets. Differences between the three modes - `VECTORS`, `POINTS`, and `POINTS_STRATIFIED` - are explained in the `SplitMode` Enum's comments. Additionally, all three modes now ensure that the ordering of the given training data has no effect on which data goes into train, ref, and val.

And here are said Enum's comments:

```python
class SplitMode(Enum):
    """
    How to split annotations between train, ref, and val sets.
    """
    # Each feature vector's points all go into train, or all go into ref, or
    # all go into val.
    #
    # The rationale behind this mode is to have greater separation between
    # training data and evaluation data, whether it's during the calibration
    # process (train vs. ref) or during evaluation of the final classifier
    # (train vs. val).
    # Here we assume the imagery is 'more different' when going across feature
    # vectors, as opposed to staying within the same feature vector. When
    # training and evaluation data are 'more different', the result is more
    # useful.
    # Thus, this mode can improve usefulness of calibration, and rigor of the
    # evaluation results.
    # However, the annotation count may not end up precisely balanced
    # between train/ref/val as desired, particularly when the feature vector
    # size is comparable to the set size. For example, if each feature vector
    # has 100 points, and the target ref-set size is 450, then the best we can
    # do is giving the ref set either 400 or 500 points.
    VECTORS = 'vectors'
    # The split is done on an individual point basis, so a single
    # feature vector may be split across train/ref/val.
    #
    # This allows the annotation count to be more precisely balanced
    # between train/ref/val.
    # However, there may be concerns that the imagery going into each set is
    # too similar, particularly when points are densely distributed within
    # each image.
    POINTS = 'points'
    # Stratified sampling by class: an A%/B%/C% train/ref/val split means
    # an A%/B%/C% split of each class.
    # The split is done on an individual point basis.
    #
    # The POINTS mode's results should already be approximately stratified due
    # to the annotations being shuffled. However, POINTS_STRATIFIED makes the
    # stratification more guaranteed. This can be useful because it makes the
    # final number of unique classes more consistent.
    #
    # Stratification checks that the number of annotations in each
    # set isn't less than the number of unique classes.
    # However, each set is NOT guaranteed to have at least 1 of each class.
    # If stratification is calculated such that a set would get <0.5
    # annotations of a class, then that set gets 0 of that class.
    POINTS_STRATIFIED = 'points_stratified'
```

The mode that's notably 'missing' is `VECTORS_STRATIFIED`, because it would be more complicated to stratify accurately when splitting at the vector level. As @yeelauren pointed out in the old PR's thread, there should be ways to implement that if desired, such as the [imbalanced-learn](https://imbalanced-learn.org/stable/combine.html) library. But it would be more complex to implement than the other modes, so it's deferred until someone really wants it.

There may be other methods/restrictions that one might want for the data split. For example, perhaps you have a hierarchy of CoralNet data where the data can be divided into several sources, each source has a set of feature vectors, and each feature vector has a set of point features; and you want each *source* to go entirely in train, or ref, or val (not split between the three). However, at this point, I think that potential need is covered by the ability to instantiate your own `TrainingTaskLabels` and thus define your own arbitrary split.

Results of experiments using this code:

| Source | Images | Mode              | Annotations | Train   | Ref   | Val    | Classes | Accuracy | CN accuracy | Train time |
| ------ | ------ | ----------------- | ----------- | ------- | ----- | ------ | ------ | -------- | ----------- | ---------- |
| 3342   | 1204   | VECTORS           | 1202766     | 1031819 | 50000 | 120947 | 12     | 95.1%    | 93.0%       | 1267.2s    |
| 3342   | 1204   | POINTS_STRATIFIED | 1203965     | 1033567 | 50000 | 120398 | 16     | 95.7%    | 93.0%       | 1484.2s    |
| 372    | 37955  | VECTORS           | 379383      | 303504  | 37958 | 37921  | 53     | 78.5%    | 78.0%       | 3441.3s    |
| 372    | 37955  | POINTS_STRATIFIED | 379538      | 303628  | 37955 | 37955  | 60     | 78.8%    | 78.0%       | 3323.5s    |
| 2112   | 4649   | VECTORS           | 232263      | 185792  | 23242 | 23229  | 46     | 86.6%    | 82.0%       | 763.9s     |
| 2112   | 4649   | POINTS_STRATIFIED | 232416      | 185930  | 23243 | 23243  | 56     | 86.8%    | 82.0%       | 755.3s     |
| 3401   | 7195   | VECTORS           | 243342      | 194598  | 24399 | 24345  | 60     | 80.0%    | 80.0%       | 1020.7s    |
| 3401   | 7195   | POINTS_STRATIFIED | 243568      | 194851  | 24359 | 24358  | 68     | 80.3%    | 80.0%       | 1123.4s    |
| 3411   | 14948  | VECTORS           | 227448      | 181933  | 22767 | 22748  | 82     | 74.1%    | 74.0%       | 1349.8s    |
| 3411   | 14948  | POINTS_STRATIFIED | 227554      | 182038  | 22758 | 22758  | 88     | 74.7%    | 74.0%       | 1389.1s    |
| 3577   | 3696   | VECTORS           | 184623      | 147635  | 18500 | 18488  | 29     | 89.7%    | 89.0%       | 536.0s     |
| 3577   | 3696   | POINTS_STRATIFIED | 184786      | 147826  | 18480 | 18480  | 36     | 89.3%    | 89.0%       | 554.9s     |
| 1579   | 16438  | VECTORS           | 164334      | 131460  | 16439 | 16435  | 50     | 77.7%    | 77.0%       | 1343.7s    |
| 1579   | 16438  | POINTS_STRATIFIED | 164341      | 131468  | 16437 | 16436  | 48     | 77.3%    | 77.0%       | 1374.4s    |
| 3697   | 1049   | VECTORS           | 52279       | 41810   | 5250  | 5219   | 18     | 78.8%    | 82.0%       | 149.0s     |
| 3697   | 1049   | POINTS_STRATIFIED | 52434       | 41947   | 5244  | 5243   | 25     | 81.5%    | 82.0%       | 159.3s     |
| 3606   | 969    | VECTORS           | 24096       | 19269   | 2425  | 2402   | 42     | 59.4%    | 69.0%       | 138.2s     |
| 3606   | 969    | POINTS_STRATIFIED | 24218       | 19374   | 2422  | 2422   | 49     | 68.4%    | 69.0%       | 127.9s     |
| 3357   | 564    | VECTORS           | 16790       | 13376   | 1710  | 1704   | 14     | 89.4%    | 86.0%       | 74.3s      |
| 3357   | 564    | POINTS_STRATIFIED | 16911       | 13527   | 1692  | 1692   | 15     | 87.3%    | 86.0%       | 77.8s      |
| 3583   | 200    | VECTORS           | 6512        | 5174    | 669   | 669    | 24     | 74.6%    | 77.0%       | 25.1s      |
| 3583   | 200    | POINTS            | 6608        | 5281    | 665   | 662    | 31     | 82.5%    | 77.0%       | 26.3s      |
| 3583   | 200    | POINTS_STRATIFIED | 6637        | 5308    | 666   | 663    | 33     | 84.0%    | 77.0%       | 30.5s      |
| 3362   | 44     | VECTORS           | 1715        | 1327    | 200   | 188    | 5      | 95.2%    | 95.0%       | 7.5s       |
| 3362   | 44     | POINTS_STRATIFIED | 1755        | 1403    | 176   | 176    | 6      | 93.2%    | 95.0%       | 6.9s       |
| 3489   | 86     | VECTORS           | 860         | 680     | 90    | 90     | 10     | 54.4%    | 80.0%       | 7.1s       |
| 3489   | 86     | POINTS_STRATIFIED | 857         | 685     | 86    | 86     | 9      | 59.3%    | 80.0%       | 5.5s       |
| 3685   | 21     | VECTORS           | 580         | 410     | 90    | 80     | 10     | 57.5%    | 46.0%       | 4.0s       |
| 3685   | 21     | POINTS_STRATIFIED | 607         | 484     | 62    | 61     | 13     | 65.6%    | 46.0%       | 3.5s       |

CSV version for potentially easier viewing: 
[2024-03 - single source runs with new sampling code.csv](https://github.com/coralnet/pyspacer/files/14548889/2024-03.-.single.source.runs.with.new.sampling.code.csv)

(To be exact, the experiments used the `training-cache-features-3` branch, which places the PR #80 feature-caching commits on top of this PR's branch).

My takeaways from the experiments:

- The default train/ref/val ratios of 80%/10%/10% (with ref being capped at 50000) are working correctly. Small discrepancies can be explained by 1) restrictions of the VECTORS mode, and 2) filtering out of classes that don't end up in both train and ref.

- Classifiers' measured accuracy hasn't been conclusively affected one way or the other by this PR, compared to the accuracy of pre-existing CoralNet classifiers trained on the same sources. That is, "Accuracy" is comparable to "CN accuracy". There are bigger accuracy fluctuations for smaller sources, as I'd expect.

- POINTS_STRATIFIED consistently results in bigger labelsets ("Classes" column) than VECTORS, as I'd expect, since with POINTS_STRATIFIED, rare classes have a better guarantee of being included in both train and ref.

- And since POINTS_STRATIFIED includes more classes than VECTORS, it also includes slightly more annotations.

- It seems that if there's a discrepancy in accuracy between VECTORS and POINTS_STRATIFIED, larger discrepancies tend to give the nod to POINTS_STRATIFIED, despite the fact that we might expect bigger labelsets to result in lower accuracy (harder to predict correctly when there are more choices). So, for smaller sources in particular, there could indeed be a concern that POINTS_STRATIFIED makes the calibration and validation 'artificially good' by training on the same images that it's validating on. For larger sources, it doesn't seem as much of a concern. (cc @kriegman)