### PR TITLE
AWS credentials through metadata service or boto auto-detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.1 (WIP)
+
+- AWS credentials can now be obtained through the following methods, in addition to spacer config values as before:
+  
+  - AWS's metadata service (STS); proof of concept from @michaelconnor00
+  - boto's auto-detection logic when neither of STS or spacer config are used (this was intended to work before, but needed fixing)
+
 ## 0.9.0
 
 - Python 3.8 and 3.9 support have been dropped; Python 3.11 support has been added.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The spacer repo can be installed in three ways.
 
 ### Config
 
-Setting spacer config variables is only necessary when using certain features. If you don't need S3 storage, and you won't load extractors remotely, you can skip this section.
+Setting spacer config variables is only necessary when using certain features. If you won't access S3 storage with static credentials, and you won't load extractors remotely, you can skip this section.
 
 See `CONFIGURABLE_VARS` in `config.py` for a full list of available variables, and for an explanation of when each variable must be configured or not.
 

--- a/scripts/aws/utils.py
+++ b/scripts/aws/utils.py
@@ -62,7 +62,7 @@ def aws_batch_job_status(jobs: list[tuple[str, DataLocation, JobMsg,
         if job_status == 'SUCCEEDED' and feat_loc is not None:
 
             # Double check that the out_key is actually there.
-            s3 = config.get_s3_conn()
+            s3 = config.get_s3_resource()
             try:
                 s3.Object(config.TEST_BUCKET, feat_loc.key).load()
             except ClientError as e:

--- a/scripts/regression/retrain_source.py
+++ b/scripts/regression/retrain_source.py
@@ -67,8 +67,8 @@ def train(source_id: int,
 def list_sources(export_name: str = 'beta_export') -> None:
     """ Lists sources available in export. """
 
-    conn = config.get_s3_conn()
-    bucket = conn.Bucket('spacer-trainingdata')
+    s3 = config.get_s3_resource()
+    bucket = s3.Bucket('spacer-trainingdata')
 
     obj_list = bucket.objects.filter(Prefix='{}/s'.format(export_name),
                                      Delimiter='images')

--- a/scripts/regression/utils.py
+++ b/scripts/regression/utils.py
@@ -20,8 +20,8 @@ def cache_local(source_root: str,
                 cache_image: bool,
                 cache_feats: bool) -> None:
     # Download data to the local to speed up training
-    conn = config.get_s3_conn()
-    bucket = conn.Bucket('spacer-trainingdata')
+    s3 = config.get_s3_resource()
+    bucket = s3.Bucket('spacer-trainingdata')
     if not os.path.exists(source_root):
         os.system('mkdir -p ' + source_root)
     if not os.path.exists(image_root):

--- a/spacer/mailman.py
+++ b/spacer/mailman.py
@@ -63,7 +63,7 @@ def env_job(): # pragma: no cover
 
         with config.log_entry_and_exit('writing res to {}'.format(
                 out_msg_loc.key)):
-            s3 = config.get_s3_conn()
+            s3 = config.get_s3_resource()
             s3.Bucket(out_msg_loc.bucket_name).put_object(
                 Key=out_msg_loc.key,
                 Body=bytes(json.dumps(job_return_msg_dict).encode('UTF-8')))

--- a/spacer/storage.py
+++ b/spacer/storage.py
@@ -160,22 +160,22 @@ class S3Storage(RemoteStorage):
         self.transfer_config = TransferConfig(use_threads=False)
 
     def store(self, key: str, stream: BytesIO):
-        s3 = config.get_s3_conn()
+        s3 = config.get_s3_resource()
         s3.Bucket(self.bucket_name).put_object(Body=stream, Key=key)
 
     def _load_remote(self, key: str):
-        s3 = config.get_s3_conn()
+        s3 = config.get_s3_resource()
         stream = BytesIO()
         s3.Object(self.bucket_name, key).download_fileobj(
             stream, Config=self.transfer_config)
         return stream
 
     def delete(self, key: str) -> None:
-        s3 = config.get_s3_conn()
+        s3 = config.get_s3_resource()
         s3.Object(self.bucket_name, key).delete()
 
     def exists(self, key: str):
-        s3 = config.get_s3_conn()
+        s3 = config.get_s3_resource()
         try:
             s3.Object(self.bucket_name, key).load()
             return True

--- a/spacer/tests/test_config.py
+++ b/spacer/tests/test_config.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
 
-from spacer.config import get_config_value
+from spacer.config import get_config_value, get_s3_resource, THREAD_LOCAL
 from spacer.exceptions import ConfigError
 
 
@@ -46,6 +46,66 @@ class TestGetConfigValue(unittest.TestCase):
     def test_not_defined_but_has_default(self):
         with mock.patch('os.getenv', mock_getenv_factory('KEY', None)):
             self.assertEqual(get_config_value('KEY', default='def.'), 'def.')
+
+
+def mock_boto3_client_factory(status_code):
+
+    def mock_boto3_client(service_name):
+        if service_name != 'sts':
+            raise ValueError
+
+        class Client:
+            @staticmethod
+            def get_caller_identity():
+                return dict(ResponseMetadata=dict(HTTPStatusCode=status_code))
+        return Client()
+    return mock_boto3_client
+
+
+class TestGetS3Resource(unittest.TestCase):
+
+    def setUp(self):
+        # Each test will start out with no S3 resource retrieved yet.
+        if hasattr(THREAD_LOCAL, 's3_resource'):
+            delattr(THREAD_LOCAL, 's3_resource')
+
+    def test_sts(self):
+        with mock.patch('boto3.client', mock_boto3_client_factory(200)):
+            with self.assertLogs(logger='spacer.config', level='INFO') as cm:
+                get_s3_resource()
+        self.assertIn(
+            "Called boto3.resource() in get_s3_resource(),"
+            " with STS credentials",
+            cm.output[0])
+
+    def test_sts_failure_response_code(self):
+        """Should fall back to spacer config / auto-detect."""
+        with mock.patch('boto3.client', mock_boto3_client_factory(400)):
+            with self.assertLogs(logger='spacer.config', level='INFO') as cm:
+                get_s3_resource()
+        self.assertIn(
+            "Called boto3.resource() in get_s3_resource(),"
+            " with spacer config or auto-detected credentials",
+            cm.output[0])
+
+    def test_spacer_config(self):
+        with self.assertLogs(logger='spacer.config', level='INFO') as cm:
+            get_s3_resource()
+        self.assertIn(
+            "Called boto3.resource() in get_s3_resource(),"
+            " with spacer config or auto-detected credentials",
+            cm.output[0])
+
+    def test_reuse(self):
+        """Three get_s3_resource() calls, but only one boto3.resource() call."""
+        with self.assertLogs(logger='spacer.config', level='INFO') as cm:
+            get_s3_resource()
+            get_s3_resource()
+            get_s3_resource()
+        self.assertIn(
+            "Called boto3.resource() in get_s3_resource()",
+            cm.output[0])
+        self.assertEqual(len(cm.output), 1)
 
 
 if __name__ == '__main__':

--- a/spacer/tests/test_data_classes.py
+++ b/spacer/tests/test_data_classes.py
@@ -75,7 +75,7 @@ class TestImageFeaturesNumpyStore(unittest.TestCase):
 
         self._test_numpy_store(s3_loc)
 
-        s3 = config.get_s3_conn()
+        s3 = config.get_s3_resource()
         s3.Object(config.TEST_BUCKET, s3_loc.key).delete()
 
     def test_fs(self):


### PR DESCRIPTION
- Metadata service (STS): This is like PR #104 from @michaelconnor00 with the addition of catching `botocore.exceptions.NoCredentialsError`, which gets raised when credentials can't be obtained this way.

- Boto auto-detection: After having another overall look at `get_s3_conn()`, I noticed that the comment of

  > If [spacer-config] credentials are None, it will default to using credentials in ~/.aws/credentials

  didn't actually hold, because the spacer code would raise a `ConfigError` if spacer-config credentials were None. I decided to just remove that check that would lead to the ConfigError. The check additionally seemed a bit misleading anyway, because it's no guarantee of having valid credentials; the `boto3.resource()` call doesn't actually use the credentials right away. You'll only know if they're valid credentials when the resource (or 'connection', as we currently call it) is actually used to access an S3 bucket or object for the first time.

Will take another look at this later to make sure I didn't miss something else.