### PR TITLE
Restrict numpy to below version 2 + small reqs technicalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   - AWS's metadata service (STS); proof of concept from @michaelconnor00
   - boto's auto-detection logic when neither of STS or spacer config are used (this was intended to work before, but needed fixing)
 
+- Updates to pip-install dependencies:
+
+  - numpy: >=1.19 to >=1.21.4,<2
+  - boto3: nothing to >=1.26.0
+
 ## 0.9.0
 
 - Python 3.8 and 3.9 support have been dropped; Python 3.11 support has been added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.9.1 (WIP)
+## 0.10.0 (WIP)
 
 - AWS credentials can now be obtained through the following methods, in addition to spacer config values as before:
   

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "scikit-learn==1.1.3",
     "torch>=1.13.1,<2.3",
     "torchvision>=0.14.1,<0.18",
-    "boto3",
+    "boto3>=1.26.0",
 ]
 license = {file = "license.txt"}
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "Pillow>=10.2.0",
-    "numpy>=1.19,<2",
+    "numpy>=1.21.4,<2",
     "scikit-learn==1.1.3",
     "torch>=1.13.1,<2.3",
     "torchvision>=0.14.1,<0.18",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "Pillow>=10.2.0",
-    "numpy>=1.19",
+    "numpy>=1.19,<2",
     "scikit-learn==1.1.3",
     "torch>=1.13.1,<2.3",
     "torchvision>=0.14.1,<0.18",

--- a/requirements/max.txt
+++ b/requirements/max.txt
@@ -1,7 +1,7 @@
 # This should install pyproject.toml's maximum accepted versions.
 
 Pillow>=10.2.0
-numpy>=1.19
+numpy>=1.19,<2
 scikit-learn==1.1.3
 torch>=1.13.1,<2.3
 torchvision>=0.14.1,<0.18

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -1,7 +1,7 @@
 # This should install pyproject.toml's minimum accepted versions.
 
 Pillow==10.2.0
-numpy==1.24.1
+numpy==1.19
 scikit-learn==1.1.3
 torch==1.13.1
 torchvision==0.14.1

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -5,4 +5,4 @@ numpy==1.24.1
 scikit-learn==1.1.3
 torch==1.13.1
 torchvision==0.14.1
-boto3==1.26.122
+boto3==1.26.0

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -1,7 +1,7 @@
 # This should install pyproject.toml's minimum accepted versions.
 
 Pillow==10.2.0
-numpy==1.19
+numpy==1.21.4
 scikit-learn==1.1.3
 torch==1.13.1
 torchvision==0.14.1


### PR DESCRIPTION
To make CI pass and be more consistent with `pyproject.toml`.