### PR TITLE
Fix feature extraction error on 'LA' image mode

### DIFF
--- a/spacer/extract_features_utils.py
+++ b/spacer/extract_features_utils.py
@@ -4,21 +4,6 @@ import numpy as np
 from PIL import Image
 
 
-def gray2rgb(im: np.ndarray) -> np.ndarray:
-    """
-    Convert gray image to RGB image
-    :param im: gray image to be converted
-    :return: RGB image
-    """
-    w, h = im.shape
-    ret = np.empty((w, h, 3), dtype=np.uint8)
-    ret[:, :, 0] = im
-    ret[:, :, 1] = im
-    ret[:, :, 2] = im
-
-    return ret
-
-
 def crop_patches(im: Image,
                  rowcols: list[tuple[int, int]],
                  crop_size: int) -> list[np.ndarray]:
@@ -29,11 +14,11 @@ def crop_patches(im: Image,
     :param crop_size: patch size
     :return: patch list
     """
-    im = np.array(im)
+    # Normalize to RGB mode (so for example, no transparency channel,
+    # and not a monochrome format) to simplify later processing steps.
+    im = im.convert('RGB')
 
-    if len(im.shape) == 2 or im.shape[2] == 1:
-        im = gray2rgb(im)
-    im = im[:, :, :3]  # only keep the first three color channels
+    im = np.array(im)
 
     pad = crop_size
     im = np.pad(im, ((pad, pad), (pad, pad), (0, 0)), mode='reflect')

--- a/spacer/tests/test_extract_features.py
+++ b/spacer/tests/test_extract_features.py
@@ -59,19 +59,17 @@ class TestDummyExtractor(unittest.TestCase):
             msg="Duplicate rowcols should be preserved, not merged")
 
 
-@require_caffe
-@require_test_extractors
-@require_test_fixtures
-class TestCaffeExtractor(unittest.TestCase):
+class BaseExtractorTest(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.extractor = FeatureExtractor.deserialize(TEST_EXTRACTORS['vgg16'])
+    # This should be set in each subclass's setUpClass().
+    extractor: FeatureExtractor
+    # This should be set in each subclass's definition.
+    expected_feature_dimension: int
 
     def setUp(self):
         config.filter_warnings()
 
-    def test_simple(self):
+    def do_test_simple(self):
 
         img = load_image(DataLocation(
             storage_type='s3',
@@ -90,10 +88,19 @@ class TestCaffeExtractor(unittest.TestCase):
         self.assertEqual(features.point_features[0].row, 100)
         self.assertEqual(features.point_features[0].col, 100)
 
-    def test_dims(self):
-        self.assertEqual(self.extractor.feature_dim, 4096)
+        self.assertEqual(
+            len(features.point_features[0].data),
+            self.expected_feature_dimension)
+        self.assertEqual(
+            features.feature_dim,
+            self.expected_feature_dimension)
 
-    def test_corner_case1(self):
+    def do_test_dims(self):
+        self.assertEqual(
+            self.extractor.feature_dim,
+            self.expected_feature_dimension)
+
+    def do_test_corner_case1(self):
         """
         This particular image caused trouble on the coralnet production server.
         The image file itself is lightly corrupted. Pillow can only read it
@@ -115,8 +122,11 @@ class TestCaffeExtractor(unittest.TestCase):
         # Check some feature metadata
         self.assertEqual(features.point_features[0].row, 148)
         self.assertEqual(features.point_features[0].col, 50)
+        self.assertEqual(
+            len(features.point_features[0].data),
+            self.expected_feature_dimension)
 
-    def test_corner_case2(self):
+    def do_test_corner_case2(self):
         """
         Another corrupted image seen in coralnet production.
         """
@@ -136,11 +146,14 @@ class TestCaffeExtractor(unittest.TestCase):
         # Check some feature metadata
         self.assertEqual(features.point_features[0].row, 190)
         self.assertEqual(features.point_features[0].col, 226)
+        self.assertEqual(
+            len(features.point_features[0].data),
+            self.expected_feature_dimension)
 
-    def test_regression(self):
+    def do_test_regression(self, legacy_features_s3_key):
         """
         This test runs the extractor on a known image and compares the
-        results to the features extracted with
+        results to features extracted with
         https://github.com/beijbom/ecs_spacer/releases/tag/1.0
         """
         rowcols = [(20, 265),
@@ -160,9 +173,21 @@ class TestCaffeExtractor(unittest.TestCase):
         )
 
         legacy_feat_loc = DataLocation(storage_type='s3',
-                                       key='08bfc10v7t.png.featurevector',
+                                       key=legacy_features_s3_key,
                                        bucket_name=config.TEST_BUCKET)
         features_legacy = ImageFeatures.load(legacy_feat_loc)
+
+        self.assertFalse(features_legacy.valid_rowcol)
+        self.assertEqual(features_legacy.npoints, len(rowcols))
+        self.assertEqual(
+            features_legacy.feature_dim,
+            self.expected_feature_dimension)
+
+        self.assertTrue(features_new.valid_rowcol)
+        self.assertEqual(features_new.npoints, len(rowcols))
+        self.assertEqual(
+            features_new.feature_dim,
+            self.expected_feature_dimension)
 
         for pf_new, pf_legacy in zip(features_new.point_features,
                                      features_legacy.point_features):
@@ -172,120 +197,58 @@ class TestCaffeExtractor(unittest.TestCase):
             self.assertTrue(pf_new.row is not None)
 
 
+@require_caffe
 @require_test_extractors
 @require_test_fixtures
-class TestEfficientNetExtractor(unittest.TestCase):
+class TestCaffeExtractor(BaseExtractorTest):
+
+    expected_feature_dimension = 4096
+
+    @classmethod
+    def setUpClass(cls):
+        cls.extractor = FeatureExtractor.deserialize(TEST_EXTRACTORS['vgg16'])
+
+    def test_simple(self):
+        super().do_test_simple()
+
+    def test_dims(self):
+        super().do_test_dims()
+
+    def test_corner_case1(self):
+        super().do_test_corner_case1()
+
+    def test_corner_case2(self):
+        super().do_test_corner_case2()
+
+    def test_regression(self):
+        super().do_test_regression('08bfc10v7t.png.featurevector')
+
+
+@require_test_extractors
+@require_test_fixtures
+class TestEfficientNetExtractor(BaseExtractorTest):
+
+    expected_feature_dimension = 1280
 
     @classmethod
     def setUpClass(cls):
         cls.extractor = FeatureExtractor.deserialize(
             TEST_EXTRACTORS['efficientnet-b0'])
 
-    def setUp(self):
-        config.filter_warnings()
-
     def test_simple(self):
-
-        img = load_image(DataLocation(
-            storage_type='s3',
-            key='edinburgh3.jpg',
-            bucket_name=config.TEST_BUCKET,
-        ))
-        features, return_msg = self.extractor(
-            im=img,
-            rowcols=[(100, 100)],
-        )
-
-        self.assertTrue(isinstance(return_msg, ExtractFeaturesReturnMsg))
-        self.assertTrue(isinstance(features, ImageFeatures))
-
-        # Check some feature metadata
-        self.assertEqual(features.point_features[0].row, 100)
-        self.assertEqual(features.point_features[0].col, 100)
-
-        self.assertEqual(len(features.point_features[0].data), 1280)
-        self.assertEqual(features.feature_dim, 1280)
+        super().do_test_simple()
 
     def test_dims(self):
-        self.assertEqual(self.extractor.feature_dim, 1280)
+        super().do_test_dims()
 
     def test_corner_case1(self):
-
-        img = load_image(DataLocation(
-            storage_type='s3',
-            key='kh6dydiix0.jpeg',
-            bucket_name=config.TEST_BUCKET,
-        ))
-        features, return_msg = self.extractor(
-            im=img,
-            rowcols=[(148, 50), (60, 425)],
-        )
-
-        self.assertTrue(isinstance(return_msg, ExtractFeaturesReturnMsg))
-        self.assertTrue(isinstance(features, ImageFeatures))
-
-        # Check some feature metadata
-        self.assertEqual(features.point_features[0].row, 148)
-        self.assertEqual(features.point_features[0].col, 50)
-        self.assertEqual(len(features.point_features[0].data), 1280)
+        super().do_test_corner_case1()
 
     def test_corner_case2(self):
-
-        img = load_image(DataLocation(
-            storage_type='s3',
-            key='sfq2mr5qbs.jpeg',
-            bucket_name=config.TEST_BUCKET,
-        ))
-        features, return_msg = self.extractor(
-            im=img,
-            rowcols=[(190, 226), (25, 359)],
-        )
-
-        self.assertTrue(isinstance(return_msg, ExtractFeaturesReturnMsg))
-        self.assertTrue(isinstance(features, ImageFeatures))
-
-        # Check some feature metadata
-        self.assertEqual(features.point_features[0].row, 190)
-        self.assertEqual(features.point_features[0].col, 226)
-        self.assertEqual(len(features.point_features[0].data), 1280)
+        super().do_test_corner_case2()
 
     def test_regression(self):
-        rowcols = [(20, 265),
-                   (76, 295),
-                   (59, 274),
-                   (151, 62),
-                   (265, 234)]
-
-        img = load_image(DataLocation(
-            storage_type='s3',
-            key='08bfc10v7t.png',
-            bucket_name=config.TEST_BUCKET,
-        ))
-        features_new, _ = self.extractor(
-            im=img,
-            rowcols=rowcols,
-        )
-
-        legacy_feat_loc = DataLocation(storage_type='s3',
-                                       key='08bfc10v7t.png.effnet.'
-                                           'ver1.featurevector',
-                                       bucket_name=config.TEST_BUCKET)
-        features_legacy = ImageFeatures.load(legacy_feat_loc)
-
-        self.assertFalse(features_legacy.valid_rowcol)
-        self.assertEqual(features_legacy.npoints, len(rowcols))
-        self.assertEqual(features_legacy.feature_dim, 1280)
-
-        self.assertTrue(features_new.valid_rowcol)
-        self.assertEqual(features_new.npoints, len(rowcols))
-        self.assertEqual(features_new.feature_dim, 1280)
-
-        for pf_new, pf_legacy in zip(features_new.point_features,
-                                     features_legacy.point_features):
-            self.assertTrue(np.allclose(pf_legacy.data, pf_new.data,
-                                        atol=1e-5))
-            self.assertTrue(pf_legacy.row is None)
-            self.assertTrue(pf_new.row is not None)
+        super().do_test_regression('08bfc10v7t.png.effnet.ver1.featurevector')
 
 
 class TestExtractorLoad(unittest.TestCase):

--- a/spacer/tests/test_extract_features_utils.py
+++ b/spacer/tests/test_extract_features_utils.py
@@ -1,17 +1,8 @@
 import unittest
 
-import numpy as np
 from PIL import Image
 
-from spacer.extract_features_utils import gray2rgb, crop_patches
-
-
-class TestGray2RGB(unittest.TestCase):
-
-    def test_default(self):
-        out_arr = gray2rgb(np.array(Image.new('L', (200, 200))))
-        out_im = Image.fromarray(out_arr)
-        self.assertEqual(out_im.mode, "RGB")
+from spacer.extract_features_utils import crop_patches
 
 
 class TestCropPatch(unittest.TestCase):


### PR DESCRIPTION
Our `gray2rgb()` function was not working as intended with the `LA` image mode (2 channels, lightness and alpha), which made an error occur later on in the feature extraction process. Here's what the error looked like for EfficientNet:

> RuntimeError: Given groups=1, weight of size [32, 3, 3, 3], expected input[2, 2, 225, 225] to have 3 channels, but got 2 channels instead

This PR uses `PIL.Image.convert('RGB')` instead of our own function, which should ensure that all Pillow-defined image modes are handled. CoralNet also uses this convert() function for its patch cropping code.

---

This reminds me of something else we might want to address later - CoralNet and pyspacer use completely different code for patch cropping (CoralNet patches are for visual inspection only, pyspacer patches are for vision-backend use). Maybe they should share the core logic to ensure that, given the same dimensions and center, the crop bounds are the exact same. But I'll put it off until we're more sure how to do this.