### PR TITLE
TorchExtractor tolist() regression fix

### DIFF
--- a/spacer/extractors/torch_extractors.py
+++ b/spacer/extractors/torch_extractors.py
@@ -60,7 +60,7 @@ class TorchExtractor(FeatureExtractor, abc.ABC):
                     features = net.extract_features(batch)
                 feats_list.extend(features.tolist())
 
-        return features, extractor_loaded_remotely
+        return feats_list, extractor_loaded_remotely
 
     @staticmethod
     def untrained_model() -> torch.nn.Module:


### PR DESCRIPTION
Fixes a PR #111 regression which made multi-batch extraction fail, and would result in warnings with newer numpy and torch versions.

The warnings were how I actually noticed the regression. I've only now added unit tests that test multi-batch extraction.