### PR TITLE
scikit-learn 1.5.2, numpy 2, Python 3.12

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,7 +19,7 @@ jobs:
             requirements: "dev"
           - python-version: "3.10"
             requirements: "min"
-          - python-version: "3.11"
+          - python-version: "3.12"
             requirements: "max"
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,6 @@
 
   - There are now `CROP_SIZE` and `BATCH_SIZE` class-level variables available.
 
-- Config and test changes:
-
-  - Some former usages of `TEST_BUCKET` have been changed to `CN_FIXTURES_BUCKET`, to more clearly denote test fixtures that are currently only available to CoralNet devs.
-
-  - The remaining usages of `TEST_BUCKET` are now usable by anyone with an AWS account. This can be any S3 bucket that you have read and write access to.
-
-  - `TEST_EXTRACTORS_BUCKET` is now known as `CN_TEST_EXTRACTORS_BUCKET`, again denoting fixtures currently only available to CoralNet devs.
-
-  Related to these changes, now more tests are runnable without needing CoralNet AWS credentials. More tests are runnable in GitHub Actions CI, as well (even though that doesn't use AWS at all).
-
 - Updates to pip-install dependencies:
 
   - Pillow: >=10.2.0 to >=10.4.0
@@ -36,6 +26,16 @@
   Also note that torch>=2.3 does not provide binaries for macOS x86.
 
 - Feature extraction should now be able to tolerate more image color modes. Previously, `LA` and possibly other modes supported by Pillow would make feature extraction crash. (Note that all modes are converted to RGB for feature extraction purposes.)
+
+- Config and test changes:
+
+  - Some former usages of `TEST_BUCKET` have been changed to `CN_FIXTURES_BUCKET`, to more clearly denote test fixtures that are currently only available to CoralNet devs.
+
+  - The remaining usages of `TEST_BUCKET` are now usable by anyone with an AWS account. This can be any S3 bucket that you have read and write access to.
+
+  - `TEST_EXTRACTORS_BUCKET` is now known as `CN_TEST_EXTRACTORS_BUCKET`, again denoting fixtures currently only available to CoralNet devs.
+
+  Related to these changes, now more tests are runnable without needing CoralNet AWS credentials. More tests are runnable in GitHub Actions CI, as well (even though that doesn't use AWS at all).
 
 - Most of the repo's standalone scripts have been removed, thus avoiding confusion about their purpose.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Updates to pip-install dependencies:
 
   - Pillow: >=10.2.0 to >=10.4.0
+  - scikit-learn: ==1.1.3 to ==1.5.2
   - tqdm: no longer required in any environment
 
 - Feature extraction should now be able to tolerate more image color modes. Previously, `LA` and possibly other modes supported by Pillow would make feature extraction crash. (Note that all modes are converted to RGB for feature extraction purposes.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
   - There are now `CROP_SIZE` and `BATCH_SIZE` class-level variables available.
 
+- Python 3.12 support added, so the supported versions are now 3.10-3.12.
+
 - Updates to pip-install dependencies:
 
   - boto3: >=1.26.0 to >=1.26.115

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Updates to pip-install dependencies:
 
+  - boto3: >=1.26.0 to >=1.26.115
   - Pillow: >=10.2.0 to >=10.4.0
   - numpy: >=1.21.4,<2 to >=1.22,<2.2
   - scikit-learn: ==1.1.3 to ==1.5.2 (loading models from previously-supported versions should still work)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
 
   Related to these changes, now more tests are runnable without needing CoralNet AWS credentials. More tests are runnable in GitHub Actions CI, as well (even though that doesn't use AWS at all).
 
+- Updates to pip-install dependencies:
+
+  - Pillow: >=10.2.0 to >=10.4.0
+  - tqdm: no longer required in any environment
+
 - Feature extraction should now be able to tolerate more image color modes. Previously, `LA` and possibly other modes supported by Pillow would make feature extraction crash. (Note that all modes are converted to RGB for feature extraction purposes.)
 
 - Most of the repo's standalone scripts have been removed, thus avoiding confusion about their purpose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,15 @@
 - Updates to pip-install dependencies:
 
   - Pillow: >=10.2.0 to >=10.4.0
-  - scikit-learn: ==1.1.3 to ==1.5.2
+  - numpy: >=1.21.4,<2 to >=1.22,<2.2
+  - scikit-learn: ==1.1.3 to ==1.5.2 (loading models from previously-supported versions should still work)
+  - torch: >=1.13.1,<2.3 to >=2.2,<2.5
+  - torchvision: >=0.14.1,<0.18 to >=0.17,<0.20
   - tqdm: no longer required in any environment
+
+  If you use numpy>=2.0, you probably also need torch>=2.3, torchvision>=0.18, and scipy>=1.13 (scipy is required by scikit-learn). Otherwise, you may get errors like "_ARRAY_API not found" and warnings like "A module that was compiled using NumPy 1.x cannot be run in NumPy 2.1.3 as it may crash."
+
+  Also note that torch>=2.3 does not provide binaries for macOS x86.
 
 - Feature extraction should now be able to tolerate more image color modes. Previously, `LA` and possibly other modes supported by Pillow would make feature extraction crash. (Note that all modes are converted to RGB for feature extraction purposes.)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
   Related to these changes, now more tests are runnable without needing CoralNet AWS credentials. More tests are runnable in GitHub Actions CI, as well (even though that doesn't use AWS at all).
 
+- Feature extraction should now be able to tolerate more image color modes. Previously, `LA` and possibly other modes supported by Pillow would make feature extraction crash. (Note that all modes are converted to RGB for feature extraction purposes.)
+
+- Most of the repo's standalone scripts have been removed, thus avoiding confusion about their purpose.
+
 ## 0.10.0
 
 - AWS credentials can now be obtained through the following methods, in addition to spacer config values as before:

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,6 @@ FROM caffe AS spacer
 # for faster builds.
 # Note that numpy is not here because it was specified before building caffe.
 RUN pip3 install coverage==7.0.5
-RUN pip3 install tqdm==4.65.0
 RUN pip3 install fire==0.5.0
 RUN pip3 install Pillow==10.2.0
 RUN pip3 install scikit-learn==1.1.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,13 +94,13 @@ FROM caffe AS spacer
 # But by doing it explicitly, the docker build can cache each step's result
 # for faster builds.
 # Note that numpy is not here because it was specified before building caffe.
-RUN pip3 install coverage==7.0.5
-RUN pip3 install fire==0.5.0
+RUN pip3 install coverage==7.6.8
+RUN pip3 install fire==0.7.0
 RUN pip3 install Pillow==11.0.0
 RUN pip3 install scikit-learn==1.5.2
 RUN pip3 install torch==2.4.1
 RUN pip3 install torchvision==0.19.1
-RUN pip3 install boto3==1.26.122
+RUN pip3 install boto3==1.34.162
 
 ENV SPACER_EXTRACTORS_CACHE_DIR=/workspace/models
 ENV PYTHONPATH="/workspace/spacer:${PYTHONPATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN git clone -b ${CLONE_TAG} --depth 1 https://github.com/Qengineering/caffe.gi
 # results in an error like "Couldn't build proto file into descriptor pool:
 # duplicate file name" when importing caffe. So we avoid protobuf 4.x.
 WORKDIR $CAFFE_ROOT/python
-RUN for req in $(cat requirements.txt) pydot 'numpy==1.24.1' 'protobuf<4'; \
+RUN for req in $(cat requirements.txt) pydot 'numpy==2.1.3' 'protobuf<4'; \
     do pip3 install $req; \
     done
 
@@ -98,8 +98,8 @@ RUN pip3 install coverage==7.0.5
 RUN pip3 install fire==0.5.0
 RUN pip3 install Pillow==11.0.0
 RUN pip3 install scikit-learn==1.5.2
-RUN pip3 install torch==1.13.1
-RUN pip3 install torchvision==0.14.1
+RUN pip3 install torch==2.4.1
+RUN pip3 install torchvision==0.19.1
 RUN pip3 install boto3==1.26.122
 
 ENV SPACER_EXTRACTORS_CACHE_DIR=/workspace/models

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ FROM caffe AS spacer
 # Note that numpy is not here because it was specified before building caffe.
 RUN pip3 install coverage==7.0.5
 RUN pip3 install fire==0.5.0
-RUN pip3 install Pillow==10.2.0
+RUN pip3 install Pillow==11.0.0
 RUN pip3 install scikit-learn==1.1.3
 RUN pip3 install torch==1.13.1
 RUN pip3 install torchvision==0.14.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ FROM caffe AS spacer
 RUN pip3 install coverage==7.0.5
 RUN pip3 install fire==0.5.0
 RUN pip3 install Pillow==11.0.0
-RUN pip3 install scikit-learn==1.1.3
+RUN pip3 install scikit-learn==1.5.2
 RUN pip3 install torch==1.13.1
 RUN pip3 install torchvision==0.14.1
 RUN pip3 install boto3==1.26.122

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PySpacer (AKA spacer) provides utilities to extract features from random point
 locations in images and then train classifiers over those features.
 It is used in the vision backend of `https://github.com/coralnet/coralnet`.
 
-Spacer currently supports Python 3.10 and 3.11.
+Spacer currently supports Python 3.10 through 3.12.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.10"
 dependencies = [
     "Pillow>=10.4.0",
     "numpy>=1.21.4,<2",
-    "scikit-learn==1.1.3",
+    "scikit-learn==1.5.2",
     "torch>=1.13.1,<2.3",
     "torchvision>=0.14.1,<0.18",
     "boto3>=1.26.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "Pillow>=10.4.0",
-    "numpy>=1.21.4,<2",
+    "numpy>=1.22,<2.2",
     "scikit-learn==1.5.2",
-    "torch>=1.13.1,<2.3",
-    "torchvision>=0.14.1,<0.18",
+    "torch>=2.2,<2.5",
+    "torchvision>=0.17,<0.20",
     "boto3>=1.26.0",
 ]
 license = {file = "license.txt"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "scikit-learn==1.5.2",
     "torch>=2.2,<2.5",
     "torchvision>=0.17,<0.20",
-    "boto3>=1.26.0",
+    "boto3>=1.26.115",
 ]
 license = {file = "license.txt"}
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Spatial image analysis with pytorch and caffe backends."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "Pillow>=10.2.0",
+    "Pillow>=10.4.0",
     "numpy>=1.21.4,<2",
     "scikit-learn==1.1.3",
     "torch>=1.13.1,<2.3",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,12 +10,20 @@ fire==0.5.0
 Pillow==11.0.0
 
 # https://numpy.org/devdocs/release.html
-numpy==1.24.1
+numpy==2.1.3
+
+# pyspacer has no direct usages of scipy. But since scikit-learn (below)
+# requires scipy, it must be installed. And since scipy requires numpy (above),
+# one may need to specify a scipy version constraint for numpy compatibility,
+# particularly when updating an existing env instead of creating a new one.
+# https://github.com/scipy/scipy/releases
+# Requires: numpy
+scipy==1.14.1
 
 # For training and classification.
 # Classifier compatibility depends heavily on this package's version.
 # https://scikit-learn.org/stable/whats_new.html
-# Requires: numpy (and scipy)
+# Requires: numpy, scipy
 scikit-learn==1.5.2
 
 # For the EfficientNet extractor
@@ -24,7 +32,7 @@ scikit-learn==1.5.2
 #
 # Matching torch and Python versions:
 # https://github.com/pytorch/vision#installation
-torch==1.13.1
-torchvision==0.14.1
+torch==2.4.1
+torchvision==0.19.1
 
 boto3>=1.26.122,<1.27

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ numpy==1.24.1
 # Classifier compatibility depends heavily on this package's version.
 # https://scikit-learn.org/stable/whats_new.html
 # Requires: numpy (and scipy)
-scikit-learn==1.1.3
+scikit-learn==1.5.2
 
 # For the EfficientNet extractor
 # https://github.com/pytorch/pytorch/releases

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,9 +2,6 @@
 
 coverage==7.0.5
 
-# https://tqdm.github.io/releases/
-tqdm==4.65.0
-
 # For mailman.py entry point
 # https://github.com/google/python-fire/releases
 fire==0.5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,7 @@ coverage==7.0.5
 fire==0.5.0
 
 # https://pillow.readthedocs.io/en/stable/releasenotes/index.html
-Pillow==10.2.0
+Pillow==11.0.0
 
 # https://numpy.org/devdocs/release.html
 numpy==1.24.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,11 @@
 # Package versions recommended for developers.
 
-coverage==7.0.5
+# https://coverage.readthedocs.io/en/latest/changes.html
+coverage==7.6.8
 
 # For mailman.py entry point
 # https://github.com/google/python-fire/releases
-fire==0.5.0
+fire==0.7.0
 
 # https://pillow.readthedocs.io/en/stable/releasenotes/index.html
 Pillow==11.0.0
@@ -35,4 +36,9 @@ scikit-learn==1.5.2
 torch==2.4.1
 torchvision==0.19.1
 
-boto3>=1.26.122,<1.27
+# https://github.com/boto/boto3/blob/develop/CHANGELOG.rst
+# Never had version issues with this, but in general when updating,
+# let's go for the final patch release of the previous minor-version
+# series. e.g. if the latest is 1.35.x, then get the latest in the
+# 1.34 series.
+boto3==1.34.162

--- a/requirements/max.txt
+++ b/requirements/max.txt
@@ -6,4 +6,4 @@ scipy
 scikit-learn==1.5.2
 torch>=2.2,<2.5
 torchvision>=0.17,<0.20
-boto3
+boto3>=1.26.115

--- a/requirements/max.txt
+++ b/requirements/max.txt
@@ -1,6 +1,6 @@
 # This should install pyproject.toml's maximum accepted versions.
 
-Pillow>=10.2.0
+Pillow>=10.4.0
 numpy>=1.19,<2
 scikit-learn==1.1.3
 torch>=1.13.1,<2.3

--- a/requirements/max.txt
+++ b/requirements/max.txt
@@ -2,7 +2,7 @@
 
 Pillow>=10.4.0
 numpy>=1.19,<2
-scikit-learn==1.1.3
+scikit-learn==1.5.2
 torch>=1.13.1,<2.3
 torchvision>=0.14.1,<0.18
 boto3

--- a/requirements/max.txt
+++ b/requirements/max.txt
@@ -1,8 +1,9 @@
 # This should install pyproject.toml's maximum accepted versions.
 
 Pillow>=10.4.0
-numpy>=1.19,<2
+numpy>=1.22,<2.2
+scipy
 scikit-learn==1.5.2
-torch>=1.13.1,<2.3
-torchvision>=0.14.1,<0.18
+torch>=2.2,<2.5
+torchvision>=0.17,<0.20
 boto3

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -2,7 +2,7 @@
 
 Pillow==10.4.0
 numpy==1.21.4
-scikit-learn==1.1.3
+scikit-learn==1.5.2
 torch==1.13.1
 torchvision==0.14.1
 boto3==1.26.0

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -11,5 +11,5 @@ scikit-learn==1.5.2
 torch==2.2.0
 # Should correspond with torch version
 torchvision==0.17.0
-# Fairly arbitrary
-boto3==1.26.0
+# Minimum for Python 3.10
+boto3==1.26.115

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -1,8 +1,15 @@
 # This should install pyproject.toml's minimum accepted versions.
 
+# Minimum for GitHub security alerts
 Pillow==10.4.0
-numpy==1.21.4
+# Minimum for GitHub security alerts
+numpy==1.22.0
+# Minimum for scikit-learn compat
+scipy==1.6.0
 scikit-learn==1.5.2
-torch==1.13.1
-torchvision==0.14.1
+# Minimum for GitHub security alerts
+torch==2.2.0
+# Should correspond with torch version
+torchvision==0.17.0
+# Fairly arbitrary
 boto3==1.26.0

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -4,8 +4,8 @@
 Pillow==10.4.0
 # Minimum for GitHub security alerts
 numpy==1.22.0
-# Minimum for scikit-learn compat
-scipy==1.6.0
+# Minimum for Python 3.10 (scikit-learn compat only needs 1.6+)
+scipy==1.7.3
 scikit-learn==1.5.2
 # Minimum for GitHub security alerts
 torch==2.2.0

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -1,6 +1,6 @@
 # This should install pyproject.toml's minimum accepted versions.
 
-Pillow==10.2.0
+Pillow==10.4.0
 numpy==1.21.4
 scikit-learn==1.1.3
 torch==1.13.1

--- a/spacer/tests/test_legacy.py
+++ b/spacer/tests/test_legacy.py
@@ -29,29 +29,17 @@ cn_beta_fixtures = {
     's812': ('4772.model', ['i672762', 'i674185']),
     's1388': ('8942.model', ['i1023182', 'i1023213'])
 }
-pyspacer_031_vgg16_fixtures = {
-    '23': {'classifier': 33358, 'images': [3286565, 3286615]},
-    '1288': {'classifier': 33360, 'images': [3286481, 3286511]},
-}
-pyspacer_031_efficientnet_fixtures = {
-    '23': {'classifier': 33369, 'images': [3286565, 3286615]},
-    '1288': {'classifier': 33368, 'images': [3286481, 3286511]},
+pyspacer_fixtures = {
+    's23': ('test.model', ['IMG_4619', 'IMG_4700']),
+    's1288': ('test.model', ['ROS-03_2018_A_30', 'ROS-06_2018_A_30']),
 }
 
 
-def pyspacer031_vgg16_fixture_location(key):
+def pyspacer_fixture_location(version, extractor, key):
     return DataLocation(
         storage_type='s3',
         bucket_name=config.CN_FIXTURES_BUCKET,
-        key='legacy_compat/pyspacer_0.3.1/vgg16/' + key
-    )
-
-
-def pyspacer031_efficientnet_fixture_location(key):
-    return DataLocation(
-        storage_type='s3',
-        bucket_name=config.CN_FIXTURES_BUCKET,
-        key='legacy_compat/pyspacer_0.3.1/efficientnet/' + key
+        key=f'legacy_compat/pyspacer_{version}/{extractor}/{key}'
     )
 
 
@@ -184,41 +172,29 @@ class TestClassifyFeatures(unittest.TestCase):
                         f"{source}/{img}.scores.json"),
                 )
 
-    def test_pyspacer_0_3_1_vgg16(self):
-        for source_id, source_data in pyspacer_031_vgg16_fixtures.items():
-            for image_id in source_data['images']:
-                classifier_id = source_data['classifier']
-                features_filename = f"{image_id}.featurevector"
-                classifier_filename = f"{classifier_id}.model"
-                scores_filename = \
-                    f"img{image_id}_clf{classifier_id}.scores.json"
+    def do_test_pyspacer(self, version, extractor):
+        for source, (clf, imgs) in pyspacer_fixtures.items():
+            for img in imgs:
                 self.run_one_test(
-                    pyspacer031_vgg16_fixture_location(
-                        f"s{source_id}/{features_filename}"),
-                    pyspacer031_vgg16_fixture_location(
-                        f"s{source_id}/{classifier_filename}"),
-                    pyspacer031_vgg16_fixture_location(
-                        f"s{source_id}/{scores_filename}"),
+                    pyspacer_fixture_location(
+                        version, extractor, f"{source}/{img}.featurevector"),
+                    pyspacer_fixture_location(
+                        version, extractor, f"{source}/{clf}"),
+                    pyspacer_fixture_location(
+                        version, extractor, f"{source}/{img}.scores.json"),
                 )
 
+    def test_pyspacer_0_3_1_vgg16(self):
+        self.do_test_pyspacer('0.3.1', 'vgg16')
+
     def test_pyspacer_0_3_1_efficientnet(self):
-        for source_id, source_data in (
-            pyspacer_031_efficientnet_fixtures.items()
-        ):
-            for image_id in source_data['images']:
-                classifier_id = source_data['classifier']
-                features_filename = f"{image_id}.featurevector"
-                classifier_filename = f"{classifier_id}.model"
-                scores_filename = \
-                    f"img{image_id}_clf{classifier_id}.scores.json"
-                self.run_one_test(
-                    pyspacer031_efficientnet_fixture_location(
-                        f"s{source_id}/{features_filename}"),
-                    pyspacer031_efficientnet_fixture_location(
-                        f"s{source_id}/{classifier_filename}"),
-                    pyspacer031_efficientnet_fixture_location(
-                        f"s{source_id}/{scores_filename}"),
-                )
+        self.do_test_pyspacer('0.3.1', 'efficientnet')
+
+    def test_pyspacer_0_9_0_vgg16(self):
+        self.do_test_pyspacer('0.9.0', 'vgg16')
+
+    def test_pyspacer_0_9_0_efficientnet(self):
+        self.do_test_pyspacer('0.9.0', 'efficientnet')
 
 
 @require_caffe

--- a/spacer/tests/test_train_utils.py
+++ b/spacer/tests/test_train_utils.py
@@ -116,7 +116,7 @@ class TestTrain(unittest.TestCase):
 
             clf_calibrated, ref_acc = train(
                 train_labels, ref_labels, feature_loc, num_epochs, 'MLP')
-            clf_param = clf_calibrated.get_params()['base_estimator']
+            clf_param = clf_calibrated.get_params()['estimator']
             self.assertEqual(
                 clf_param.hidden_layer_sizes, hls,
                 msg="Hidden layer sizes should correspond to label count")


### PR DESCRIPTION
It's time for dependency updates; Dependabot alerts are piling up a bit.

I thought scikit-learn would have been the main one to watch out for in terms of compatibility, but it was actually the combo of numpy and torch which was trickiest. torch 2.4 made a move towards better safety of `torch.load()` by issuing a warning if general-purpose unpickling was used, as opposed to a limited unpickling mode which is less powerful (thus safer) but may need adding to an allow-list to load everything we need. So that's what I had to do in commit d8b5f41, with the additional complication that one of the things to be loaded was from `numpy.core`, which got renamed to `numpy._core` in numpy 2.

The CHANGELOG has a couple of notes about compatible versions:

> If you use numpy>=2.0, you probably also need torch>=2.3, torchvision>=0.18, and scipy>=1.13 (scipy is required by scikit-learn). Otherwise, you may get errors like "_ARRAY_API not found" and warnings like "A module that was compiled using NumPy 1.x cannot be run in NumPy 2.1.3 as it may crash."
>
> Also note that torch>=2.3 does not provide binaries for macOS x86.

There are still no issues with building Caffe, even on numpy 2.

By updating everything, it looks like we're able to support Python 3.12 in the meantime.