### PR TITLE
URLStorage: wrap read() TimeoutError in a URLDownloadError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.1 (WIP)
+
+- `URLStorage` downloads: if a `TimeoutError` occurs while calling `read()` on the response, the error will be wrapped in a `spacer.exceptions.URLDownloadError`. Previously this was only the case for the `urlopen()` call, not the `read()` call.
+
 ## 0.11.0
 
 - Feature extractor class changes:

--- a/spacer/storage.py
+++ b/spacer/storage.py
@@ -117,10 +117,11 @@ class URLStorage(RemoteStorage):
 
         try:
             download_bytes = download_response.read()
-        except IncompleteRead as e:
+        except (IncompleteRead, TimeoutError) as e:
             # http.client.IncompleteRead - <num> bytes read, <num> more expected
             #   - In some cases this seems to just happen randomly?
             #     But it'll depend on the URL's server.
+            # TimeoutError: The read operation timed out
             raise URLDownloadError(
                 f"Couldn't read the full response from the URL '{url}'.", e)
 

--- a/spacer/tests/test_storage.py
+++ b/spacer/tests/test_storage.py
@@ -192,7 +192,7 @@ class TestURLStorage(unittest.TestCase):
                 self.storage.load('a_url')
         self.assertIn("404", str(cm.exception))
 
-    def test_timeout(self):
+    def test_timeout_urlopen(self):
         with mock.patch('urllib.request.urlopen', raise_timeout):
             with self.assertRaises(URLDownloadError) as cm:
                 self.storage.load('a_url')
@@ -202,6 +202,21 @@ class TestURLStorage(unittest.TestCase):
         class FakeResponse:
             def read(self):
                 raise IncompleteRead(b'')
+
+        def return_fake_response(*args, **kwargs):
+            return FakeResponse()
+
+        with mock.patch.object(
+            urllib.request, 'urlopen', return_fake_response
+        ):
+            with self.assertRaises(URLDownloadError) as cm:
+                self.storage.load('url')
+        self.assertIn("full response", str(cm.exception))
+
+    def test_timeout_read(self):
+        class FakeResponse:
+            def read(self):
+                raise TimeoutError("Test")
 
         def return_fake_response(*args, **kwargs):
             return FakeResponse()


### PR DESCRIPTION
In `URLStorage` downloads, if a `TimeoutError` occurs while calling `read()` on the response, the error will now be wrapped in a `spacer.exceptions.URLDownloadError`. Previously this was only the case for the `urlopen()` call, not the `read()` call.

This added case is consistent with the stated design of URLDownloadError: "helps to indicate that the exceptions are from a URLStorage url and not some other kind of download/read."

The effect of this PR for CoralNet is that when these particular errors happen during deploy API usage, they will still be logged, but they won't be reported to admins anymore - just like all the other URLDownloadError cases in API usage. And the reason for that design is that most of the time, the error just indicates that the URL given through the deploy API pointed to a web server that was responding too slowly at the time.