### PR TITLE
PyTorch 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 0.11.1 (WIP)
+## 0.12.0 (WIP)
+
+- Updates to pip-install dependencies:
+
+  - torch: >=2.2,<2.5 to >=2.6,<2.7
+  - torchvision: >=0.17,<0.20 to >=0.21,<0.22
 
 - `URLStorage` downloads: if a `TimeoutError` occurs while calling `read()` on the response, the error will be wrapped in a `spacer.exceptions.URLDownloadError`. Previously this was only the case for the `urlopen()` call, not the `read()` call.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,8 +98,8 @@ RUN pip3 install coverage==7.6.8
 RUN pip3 install fire==0.7.0
 RUN pip3 install Pillow==11.0.0
 RUN pip3 install scikit-learn==1.5.2
-RUN pip3 install torch==2.4.1
-RUN pip3 install torchvision==0.19.1
+RUN pip3 install torch==2.6.0
+RUN pip3 install torchvision==0.21.0
 RUN pip3 install boto3==1.34.162
 
 ENV SPACER_EXTRACTORS_CACHE_DIR=/workspace/models

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
     "Pillow>=10.4.0",
     "numpy>=1.22,<2.2",
     "scikit-learn==1.5.2",
-    "torch>=2.2,<2.5",
-    "torchvision>=0.17,<0.20",
+    "torch>=2.6,<2.7",
+    "torchvision>=0.21,<0.22",
     "boto3>=1.26.115",
 ]
 license = {file = "license.txt"}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,8 +33,8 @@ scikit-learn==1.5.2
 #
 # Matching torch and Python versions:
 # https://github.com/pytorch/vision#installation
-torch==2.4.1
-torchvision==0.19.1
+torch==2.6.0
+torchvision==0.21.0
 
 # https://github.com/boto/boto3/blob/develop/CHANGELOG.rst
 # Never had version issues with this, but in general when updating,

--- a/requirements/max.txt
+++ b/requirements/max.txt
@@ -1,9 +1,14 @@
 # This should install pyproject.toml's maximum accepted versions.
 
+# 11.0 supports up to Python 3.13
 Pillow>=10.4.0
+# 2.1 supports up to Python 3.13
 numpy>=1.22,<2.2
 scipy
+# Supports up to Python 3.12; 1.6 adds 3.13
 scikit-learn==1.5.2
-torch>=2.2,<2.5
-torchvision>=0.17,<0.20
+# Supports up to Python 3.13
+torch>=2.6,<2.7
+torchvision>=0.21,<0.22
+# 1.35.36 adds "provisional" Python 3.13 support
 boto3>=1.26.115

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -8,8 +8,8 @@ numpy==1.22.0
 scipy==1.7.3
 scikit-learn==1.5.2
 # Minimum for GitHub security alerts
-torch==2.2.0
+torch==2.6.0
 # Should correspond with torch version
-torchvision==0.17.0
+torchvision==0.21.0
 # Minimum for Python 3.10
 boto3==1.26.115

--- a/spacer/extractors/torch_extractors.py
+++ b/spacer/extractors/torch_extractors.py
@@ -110,10 +110,14 @@ class TorchExtractor(FeatureExtractor, abc.ABC):
 
             safe_globals = [
                 np.dtype,
-                np.dtypes.Int64DType,
                 # torch 2.5.0 doesn't need this, but at least 2.4.1 does.
                 codecs.encode,
             ]
+
+            # In numpy>=1.25, numpy.dtypes is present.
+            if hasattr(np, 'dtypes'):
+                safe_globals.append(np.dtypes.Int64DType)
+
             # In numpy>=2, numpy._core is present, and numpy.core is a
             # deprecated alias of numpy._core.
             if hasattr(np, '_core'):
@@ -127,6 +131,7 @@ class TorchExtractor(FeatureExtractor, abc.ABC):
                 ])
             else:
                 safe_globals.append(np.core.multiarray.scalar)
+
             torch.serialization.add_safe_globals(safe_globals)
 
             # Load weights


### PR DESCRIPTION
This puts torch and torchvision at the latest versions, 2.6 and 0.21, to address a security alert regarding older torch versions.