### PR TITLE
Test PR to run CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - `URLStorage` downloads: if a `TimeoutError` occurs while calling `read()` on the response, the error will be wrapped in a `spacer.exceptions.URLDownloadError`. Previously this was only the case for the `urlopen()` call, not the `read()` call.
 
+- (This is a test change)
+
 ## 0.11.0
 
 - Feature extractor class changes:


### PR DESCRIPTION
I don't understand why PR #118's CI failure didn't come up before. Testing to see if it's something that came up with no code changes (in which case this PR's CI would fail), or if it's actually something to do with that PR's changes (in which case this PR's CI would pass).