### PR TITLE
Fix TorchExtractor.load_weights() for numpy 1.26.1 to 1.26.5

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,6 +21,8 @@ jobs:
             requirements: "min"
           - python-version: "3.12"
             requirements: "max"
+          - python-version: "3.12"
+            requirements: "np1"
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.1 (WIP)
+
+- Fixed an `AttributeError` in `TorchExtractor.load_weights()` that would happen on numpy 1.26.1 through 1.26.5. These are the versions where `numpy._core` exists but doesn't have attributes available; on these versions we now access `numpy.core` like on other 1.x versions.
+
 ## 0.12.0
 
 - Updates to pip-install dependencies:

--- a/requirements/np1.txt
+++ b/requirements/np1.txt
@@ -1,0 +1,9 @@
+# Like max.txt but sticking with numpy less than 2.
+
+Pillow>=10.4.0
+numpy>=1.22,<2
+scipy
+scikit-learn==1.5.2
+torch>=2.6,<2.7
+torchvision>=0.21,<0.22
+boto3>=1.26.115

--- a/spacer/extractors/torch_extractors.py
+++ b/spacer/extractors/torch_extractors.py
@@ -118,9 +118,13 @@ class TorchExtractor(FeatureExtractor, abc.ABC):
             if hasattr(np, 'dtypes'):
                 safe_globals.append(np.dtypes.Int64DType)
 
-            # In numpy>=2, numpy._core is present, and numpy.core is a
-            # deprecated alias of numpy._core.
-            if hasattr(np, '_core'):
+            if np.version.version[0] != '1':
+                # We have numpy>=2, where numpy.core is a deprecated alias of
+                # numpy._core.
+                # Note that numpy._core exists as some kind of stub in numpy
+                # >=1.26.1,<2 and issues can arise with trying to reference
+                # that here. So we don't want to be here in all cases that
+                # _core exists; only in the numpy>=2 case.
                 safe_globals.extend([
                     np._core.multiarray.scalar,
                     # To load core stuff created in numpy<2 while running numpy>=2,


### PR DESCRIPTION
Fixed an `AttributeError` in `TorchExtractor.load_weights()` that would happen on numpy 1.26.1 through 1.26.5. These are the versions where `numpy._core` exists but doesn't have attributes available; on these versions we now access `numpy.core` like on other 1.x versions.

(Noticed this problem because SageMaker JupyterLab currently has numpy 1.26.4 by default.)