### PR TITLE
torch >=2.6,<2.9 and torchvision >=0.21,<0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Updates to pip-install dependencies:
 
-  - torch: >=2.6,<2.7 to >=2.7.1,<2.8
-  - torchvision: >=0.21,<0.22 to >=0.22.1,<0.23
+  - torch: >=2.6,<2.7 to >=2.6,<2.9
+  - torchvision: >=0.21,<0.22 to >=0.21,<0.24
 
 - Fixed an `AttributeError` in `TorchExtractor.load_weights()` that would happen on numpy 1.26.1 through 1.26.5. These are the versions where `numpy._core` exists but doesn't have attributes available; on these versions we now access `numpy.core` like on other 1.x versions.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,8 +98,8 @@ RUN pip3 install coverage==7.6.8
 RUN pip3 install fire==0.7.0
 RUN pip3 install Pillow==11.0.0
 RUN pip3 install scikit-learn==1.5.2
-RUN pip3 install torch==2.7.1
-RUN pip3 install torchvision==0.22.1
+RUN pip3 install torch==2.8.0
+RUN pip3 install torchvision==0.23.0
 RUN pip3 install boto3==1.34.162
 
 ENV SPACER_EXTRACTORS_CACHE_DIR=/workspace/models

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
     "Pillow>=10.4.0",
     "numpy>=1.22,<2.2",
     "scikit-learn==1.5.2",
-    "torch>=2.7.1,<2.8",
-    "torchvision>=0.22.1,<0.23",
+    "torch>=2.6,<2.9",
+    "torchvision>=0.21,<0.24",
     "boto3>=1.26.115",
 ]
 license = {file = "license.txt"}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,8 +33,8 @@ scikit-learn==1.5.2
 #
 # Matching torch and Python versions:
 # https://github.com/pytorch/vision#installation
-torch==2.7.1
-torchvision==0.22.1
+torch==2.8.0
+torchvision==0.23.0
 
 # https://github.com/boto/boto3/blob/develop/CHANGELOG.rst
 # Never had version issues with this, but in general when updating,

--- a/requirements/max.txt
+++ b/requirements/max.txt
@@ -8,7 +8,7 @@ scipy
 # Supports up to Python 3.12; 1.6 adds 3.13
 scikit-learn==1.5.2
 # Supports up to Python 3.13
-torch>=2.7.1,<2.8
-torchvision>=0.22.1,<0.23
+torch>=2.6,<2.9
+torchvision>=0.21,<0.24
 # 1.35.36 adds "provisional" Python 3.13 support
 boto3>=1.26.115

--- a/requirements/min.txt
+++ b/requirements/min.txt
@@ -7,9 +7,12 @@ numpy==1.22.0
 # Minimum for Python 3.10 (scikit-learn compat only needs 1.6+)
 scipy==1.7.3
 scikit-learn==1.5.2
-# Minimum for GitHub security alerts
-torch==2.7.1
+# Not minimum for GitHub security alerts (that'd be 2.8), but this is a
+# big package to pin to a very recent version.
+# In SageMaker, for example, their default version is a bit behind,
+# and the install time can make it onerous to use a newer one.
+torch==2.6
 # Should correspond with torch version
-torchvision==0.22.1
+torchvision==0.21.0
 # Minimum for Python 3.10
 boto3==1.26.115

--- a/requirements/np1.txt
+++ b/requirements/np1.txt
@@ -4,6 +4,6 @@ Pillow>=10.4.0
 numpy>=1.22,<2
 scipy
 scikit-learn==1.5.2
-torch>=2.7.1,<2.8
-torchvision>=0.22.1,<0.23
+torch>=2.6,<2.9
+torchvision>=0.21,<0.24
 boto3>=1.26.115


### PR DESCRIPTION
This adds lenience in both the new and old directions.

torch 2.8 is currently the minimum to address GitHub security alerts, but torch is a big package to pin to a very recent version.

For example, SageMaker's default torch version is 2.6 at this time of writing, and (long story short) the time needed to install a different torch version can make it onerous to use a newer torch version with SageMaker.