### PR TITLE
Allow generalized ClassifierTrainer inheritance, keeping backwards compatibility with the MiniBatchTrainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ message = TrainClassifierMsg(
     # For your bookkeeping.
     job_token='classifier1',
     # 'minibatch' is currently the only trainer that spacer defines.
-    trainer_name='minibatch',
+    trainer='minibatch',
     # How many iterations the training algorithm should run; more epochs
     # = more opportunity to converge to a better fit, but slower.
     nbr_epochs=10,

--- a/README.md
+++ b/README.md
@@ -260,8 +260,10 @@ from spacer.task_utils import preprocess_labels
 message = TrainClassifierMsg(
     # For your bookkeeping.
     job_token='classifier1',
-    # 'minibatch' is the default trainer defined by spacer.
-    # Custom trainers can be created by subclassing ClassifierTrainer.
+    # 'minibatch' specifies spacer's default trainer, MiniBatchTrainer,
+    # with default parameters.
+    # For more control, you can instead pass a MiniBatchTrainer instance, or
+    # define your own ClassifierTrainer subclass and pass an instance of it.
     trainer='minibatch',
     # How many iterations the training algorithm should run; more epochs
     # = more opportunity to converge to a better fit, but slower.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ from spacer.task_utils import preprocess_labels
 message = TrainClassifierMsg(
     # For your bookkeeping.
     job_token='classifier1',
-    # 'minibatch' is currently the only trainer that spacer defines.
+    # 'minibatch' is the default trainer defined by spacer.
+    # Custom trainers can be created by subclassing ClassifierTrainer.
     trainer='minibatch',
     # How many iterations the training algorithm should run; more epochs
     # = more opportunity to converge to a better fit, but slower.

--- a/spacer/config.py
+++ b/spacer/config.py
@@ -212,6 +212,8 @@ CLASSIFIER_TYPES = [
     'MLP'
 ]
 
+# Deprecated: use ClassifierTrainer instances or trainer_factory() instead.
+# Kept for backward compatibility with code that checks membership.
 TRAINER_NAMES = [
     'minibatch'
 ]

--- a/spacer/tasks.py
+++ b/spacer/tasks.py
@@ -18,7 +18,7 @@ from spacer.messages import \
     ClassifyReturnMsg, JobMsg, JobReturnMsg
 from spacer.storage import load_image, load_classifier, store_classifier
 from spacer.task_utils import check_extract_inputs, preprocess_labels
-from spacer.train_classifier import ClassifierTrainer, trainer_factory
+from spacer.train_classifier import ClassifierTrainer
 
 logger = getLogger(__name__)
 
@@ -37,7 +37,7 @@ def extract_features(msg: ExtractFeaturesMsg) -> ExtractFeaturesReturnMsg:
 
 
 def train_classifier(msg: TrainClassifierMsg) -> TrainClassifierReturnMsg:
-    trainer: ClassifierTrainer = trainer_factory(msg.trainer_name)
+    trainer: ClassifierTrainer = msg.trainer
 
     labels = preprocess_labels(msg.labels)
     logger.debug(

--- a/spacer/tests/test_mailman.py
+++ b/spacer/tests/test_mailman.py
@@ -88,7 +88,7 @@ class TestProcessJobErrorHandling(unittest.TestCase):
             msg = JobMsg(task_name='train_classifier',
                          tasks=[TrainClassifierMsg(
                              job_token='my_job',
-                             trainer_name='minibatch',
+                             trainer='minibatch',
                              nbr_epochs=1,
                              clf_type=clf_type,
                              labels=TrainingTaskLabels.example(),

--- a/spacer/tests/test_storage.py
+++ b/spacer/tests/test_storage.py
@@ -25,7 +25,8 @@ from spacer.storage import \
     store_classifier, \
     clear_memory_storage
 from spacer.tests.utils import cn_beta_fixture_location
-from spacer.train_utils import make_random_data, train
+from spacer.train_classifier import MiniBatchTrainer
+from spacer.train_utils import make_random_data
 from .decorators import require_cn_fixtures, require_s3
 from .utils import temp_filesystem_data_location
 
@@ -84,7 +85,7 @@ class BaseStorageTest(unittest.TestCase, abc.ABC):
             feature_dim=5,
             feature_loc_base=features_loc_template,
         )
-        clf, _ = train(
+        clf, _ = MiniBatchTrainer()._train(
             train_labels, ref_labels, 1, 'LR')
         store_classifier(self.tmp_model_loc, clf)
         self.assertTrue(self.storage.exists(self.tmp_model_loc.key))

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -212,7 +212,7 @@ class TestTrainClassifier(unittest.TestCase):
 
         msg = TrainClassifierMsg(
             job_token='test',
-            trainer_name='minibatch',
+            trainer='minibatch',
             nbr_epochs=1,
             clf_type=clf_type,
             labels=labels,
@@ -280,7 +280,7 @@ class TestTrainClassifier(unittest.TestCase):
 
         msg = TrainClassifierMsg(
             job_token='test',
-            trainer_name='minibatch',
+            trainer='minibatch',
             nbr_epochs=1,
             clf_type='LR',
             labels=TrainingTaskLabels(
@@ -330,7 +330,7 @@ class TestTrainClassifier(unittest.TestCase):
         ):
             msg = TrainClassifierMsg(
                 job_token='test',
-                trainer_name='minibatch',
+                trainer='minibatch',
                 nbr_epochs=2,
                 clf_type='MLP',
                 labels=preprocess_labels(make_random_data(
@@ -389,7 +389,7 @@ class ClassifyReturnMsgTest(unittest.TestCase):
 
         msg = TrainClassifierMsg(
             job_token='test',
-            trainer_name='minibatch',
+            trainer='minibatch',
             nbr_epochs=1,
             clf_type='MLP',
             labels=labels,

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -42,7 +42,8 @@ from spacer.tasks import (
 )
 from spacer.task_utils import preprocess_labels
 from spacer.tests.utils import cn_beta_fixture_location, temp_s3_filepaths
-from spacer.train_utils import make_random_data, train
+from spacer.train_classifier import MiniBatchTrainer
+from spacer.train_utils import make_random_data
 from .decorators import require_cn_fixtures, require_s3
 
 TEST_URL = \
@@ -201,7 +202,7 @@ class TestTrainClassifier(unittest.TestCase):
 
         # Train once by calling directly so that we have a
         # previous classifier.
-        clf, _ = train(
+        clf, _ = MiniBatchTrainer()._train(
             labels.train, labels.ref, 1, clf_type)
 
         previous_classifier_loc = DataLocation(storage_type='memory',

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -41,7 +41,11 @@ from spacer.tasks import (
     train_classifier,
 )
 from spacer.task_utils import preprocess_labels
-from spacer.tests.utils import cn_beta_fixture_location, temp_s3_filepaths
+from spacer.tests.utils import (
+    cn_beta_fixture_location,
+    temp_s3_filepaths,
+    spy_decorator
+)
 from spacer.train_classifier import MiniBatchTrainer
 from spacer.train_utils import make_random_data
 from .decorators import require_cn_fixtures, require_s3
@@ -166,20 +170,6 @@ class TestExtractFeatures(unittest.TestCase):
         _ = extract_features(msg)
         features = ImageFeatures.load(msg.feature_loc)
         self.assertEqual(len(features.point_features), len(msg.rowcols))
-
-
-def spy_decorator(method_to_decorate):
-    """
-    A way to track calls to a class's instance method, across all instances
-    of the class. From:
-    https://stackoverflow.com/a/41599695
-    """
-    mock_obj = mock.MagicMock()
-    def wrapper(self, *args, **kwargs):
-        mock_obj(*args, **kwargs)
-        return method_to_decorate(self, *args, **kwargs)
-    wrapper.mock_obj = mock_obj
-    return wrapper
 
 
 class TestTrainClassifier(unittest.TestCase):

--- a/spacer/tests/test_train_classifier.py
+++ b/spacer/tests/test_train_classifier.py
@@ -5,7 +5,9 @@ import numpy as np
 
 from spacer import config
 from spacer.data_classes import DataLocation
-from spacer.train_classifier import trainer_factory
+from spacer.train_classifier import (
+    ClassifierTrainer, MiniBatchTrainer, trainer_factory,
+)
 from spacer.train_utils import make_random_data, train
 
 
@@ -68,6 +70,55 @@ class TestDefaultTrainerDummyData(unittest.TestCase):
                                " Consider lowering the acc threshold.")
             self.assertEqual(len(return_message.pc_accs), 2)
             self.assertEqual(len(return_message.ref_accs), num_epochs)
+
+
+class TestTrainerFactory(unittest.TestCase):
+
+    def test_builtin_alias(self):
+        trainer = trainer_factory('minibatch')
+        self.assertIsInstance(trainer, MiniBatchTrainer)
+
+    def test_class_path(self):
+        trainer = trainer_factory('spacer.train_classifier.MiniBatchTrainer')
+        self.assertIsInstance(trainer, MiniBatchTrainer)
+
+    def test_invalid_path(self):
+        with self.assertRaises((ImportError, ModuleNotFoundError)):
+            trainer_factory('no.such.module.Trainer')
+
+    def test_invalid_class_name(self):
+        with self.assertRaises(AttributeError):
+            trainer_factory('spacer.train_classifier.NoSuchTrainer')
+
+    def test_not_a_trainer(self):
+        # ValResults is not a ClassifierTrainer subclass
+        with self.assertRaises(TypeError):
+            trainer_factory('spacer.data_classes.ValResults')
+
+
+class TestTrainerSerialization(unittest.TestCase):
+
+    def test_serialize_round_trip(self):
+        trainer = MiniBatchTrainer()
+        data = trainer.serialize()
+        restored = ClassifierTrainer.deserialize(data)
+        self.assertIsInstance(restored, MiniBatchTrainer)
+        self.assertEqual(trainer, restored)
+
+    def test_serialize_content(self):
+        trainer = MiniBatchTrainer()
+        data = trainer.serialize()
+        self.assertEqual(
+            data,
+            {'class_path': 'spacer.train_classifier.MiniBatchTrainer'},
+        )
+
+    def test_repr(self):
+        trainer = MiniBatchTrainer()
+        self.assertIn('MiniBatchTrainer', repr(trainer))
+
+    def test_equality(self):
+        self.assertEqual(MiniBatchTrainer(), MiniBatchTrainer())
 
 
 if __name__ == '__main__':

--- a/spacer/tests/test_train_classifier.py
+++ b/spacer/tests/test_train_classifier.py
@@ -1,14 +1,16 @@
 import random
 import unittest
+from unittest import mock
 
 import numpy as np
 
 from spacer import config
-from spacer.data_classes import DataLocation
+from spacer.data_classes import DataLocation, ImageLabels
 from spacer.train_classifier import (
     ClassifierTrainer, MiniBatchTrainer, trainer_factory,
 )
 from spacer.train_utils import make_random_data
+from spacer.tests.utils import spy_decorator
 
 
 class TestDefaultTrainerDummyData(unittest.TestCase):
@@ -223,8 +225,23 @@ class TestTrain(unittest.TestCase):
         ref_labels = make_random_data(
             1, [1, 2], 20, 5, feature_loc)
         trainer = MiniBatchTrainer(batch_size=50)
-        clf, ref_acc = trainer._train(train_labels, ref_labels, 2, 'LR')
+
+        load_spied = spy_decorator(ImageLabels.load_data_in_batches)
+        with mock.patch.object(
+            ImageLabels, 'load_data_in_batches', load_spied
+        ):
+            clf, ref_acc = trainer._train(
+                train_labels, ref_labels, 2, 'LR')
+
         self.assertEqual(len(ref_acc), 2)
+        # Verify batch_size=50 was passed through to load_data_in_batches.
+        # Called once per epoch with random_seed=epoch_number, plus once
+        # for ref data loading via load_all_data().
+        load_spied.mock_obj.assert_any_call(batch_size=50, random_seed=0)
+        load_spied.mock_obj.assert_any_call(batch_size=50, random_seed=1)
+        load_spied.mock_obj.assert_any_call(
+            batch_size=None, random_seed=None)
+        self.assertEqual(load_spied.mock_obj.call_count, 3)
 
     def test_explicit_mlp_params(self):
         feature_loc = DataLocation(storage_type='memory', key='')

--- a/spacer/tests/test_train_classifier.py
+++ b/spacer/tests/test_train_classifier.py
@@ -8,7 +8,7 @@ from spacer.data_classes import DataLocation
 from spacer.train_classifier import (
     ClassifierTrainer, MiniBatchTrainer, trainer_factory,
 )
-from spacer.train_utils import make_random_data, train
+from spacer.train_utils import make_random_data
 
 
 class TestDefaultTrainerDummyData(unittest.TestCase):
@@ -46,9 +46,9 @@ class TestDefaultTrainerDummyData(unittest.TestCase):
         trainer = trainer_factory('minibatch')
         for clf_type in config.CLASSIFIER_TYPES:
             # 2 previous classifiers
-            pc_clf1, _ = train(
+            pc_clf1, _ = MiniBatchTrainer()._train(
                 train_data, ref_data, 1, clf_type)
-            pc_clf2, _ = train(
+            pc_clf2, _ = MiniBatchTrainer()._train(
                 train_data, ref_data, 1, clf_type)
 
             clf, val_results, return_message = trainer(
@@ -119,6 +119,127 @@ class TestTrainerSerialization(unittest.TestCase):
 
     def test_equality(self):
         self.assertEqual(MiniBatchTrainer(), MiniBatchTrainer())
+
+    def test_serialize_default_only_class_path(self):
+        trainer = MiniBatchTrainer()
+        self.assertEqual(
+            trainer.serialize(),
+            {'class_path': 'spacer.train_classifier.MiniBatchTrainer'},
+        )
+
+    def test_serialize_with_custom_params(self):
+        trainer = MiniBatchTrainer(batch_size=10000)
+        data = trainer.serialize()
+        self.assertIn('batch_size', data)
+        self.assertEqual(data['batch_size'], 10000)
+
+    def test_round_trip_with_custom_params(self):
+        trainer = MiniBatchTrainer(batch_size=10000, sgd_loss='hinge')
+        data = trainer.serialize()
+        restored = ClassifierTrainer.deserialize(data)
+        self.assertEqual(trainer, restored)
+        self.assertEqual(restored.batch_size, 10000)
+        self.assertEqual(restored.sgd_loss, 'hinge')
+
+
+class TestTrain(unittest.TestCase):
+
+    def do_basic_run(self, class_list, clf_type):
+
+        n_traindata = 5
+        n_refdata = 1
+        points_per_image = 20
+        feature_dim = 5
+        num_epochs = 4
+        feature_loc = DataLocation(storage_type='memory', key='')
+
+        train_labels = make_random_data(
+            n_traindata, class_list, points_per_image,
+            feature_dim, feature_loc,
+        )
+        ref_labels = make_random_data(
+            n_refdata, class_list, points_per_image,
+            feature_dim, feature_loc,
+        )
+
+        clf_calibrated, ref_acc = MiniBatchTrainer()._train(
+            train_labels, ref_labels,
+            num_epochs, clf_type,
+        )
+
+        self.assertEqual(
+            len(ref_acc), num_epochs,
+            msg="Sanity check: expecting one ref_acc element per epoch")
+
+    def test_lr_int_labels(self):
+        self.do_basic_run([1, 2], 'LR')
+
+    def test_mlp_int_labels(self):
+        self.do_basic_run([1, 2], 'MLP')
+
+    def test_lr_str_labels(self):
+        self.do_basic_run(['Porites', 'CCA', 'Sand'], 'LR')
+
+    def test_mlp_str_labels(self):
+        self.do_basic_run(['Porites', 'CCA', 'Sand'], 'MLP')
+
+    def test_mlp_hybrid_mode(self):
+
+        param_sets = [
+            (11, 20, (100,), 1e-3),
+            (100, 1000, (200, 100), 1e-4),
+        ]
+
+        for (n_traindata, points_per_image, hls, lr) in param_sets:
+            feature_dim = 5
+            class_list = [1, 2]
+            num_epochs = 4
+            feature_loc = DataLocation(storage_type='memory', key='')
+
+            train_labels = make_random_data(
+                n_traindata, class_list, points_per_image,
+                feature_dim, feature_loc,
+            )
+            ref_labels = make_random_data(
+                1, class_list, points_per_image,
+                feature_dim, feature_loc,
+            )
+
+            clf_calibrated, ref_acc = MiniBatchTrainer()._train(
+                train_labels, ref_labels, num_epochs, 'MLP')
+            clf_param = clf_calibrated.get_params()['estimator']
+            self.assertEqual(
+                clf_param.hidden_layer_sizes, hls,
+                msg="Hidden layer sizes should correspond to label count")
+            self.assertEqual(
+                clf_param.learning_rate_init, lr,
+                msg="Learning rate init value should correspond to label"
+                    " count")
+
+    def test_custom_batch_size(self):
+        feature_loc = DataLocation(storage_type='memory', key='')
+        train_labels = make_random_data(
+            5, [1, 2], 20, 5, feature_loc)
+        ref_labels = make_random_data(
+            1, [1, 2], 20, 5, feature_loc)
+        trainer = MiniBatchTrainer(batch_size=50)
+        clf, ref_acc = trainer._train(train_labels, ref_labels, 2, 'LR')
+        self.assertEqual(len(ref_acc), 2)
+
+    def test_explicit_mlp_params(self):
+        feature_loc = DataLocation(storage_type='memory', key='')
+        train_labels = make_random_data(
+            5, [1, 2], 20, 5, feature_loc)
+        ref_labels = make_random_data(
+            1, [1, 2], 20, 5, feature_loc)
+        trainer = MiniBatchTrainer(
+            mlp_hidden_layer_sizes=(50,),
+            mlp_learning_rate_init=0.01,
+        )
+        clf, ref_acc = trainer._train(train_labels, ref_labels, 2, 'MLP')
+        clf_param = clf.get_params()['estimator']
+        self.assertEqual(clf_param.hidden_layer_sizes, (50,))
+        self.assertEqual(clf_param.learning_rate_init, 0.01)
 
 
 if __name__ == '__main__':

--- a/spacer/tests/test_train_classifier.py
+++ b/spacer/tests/test_train_classifier.py
@@ -185,10 +185,14 @@ class TestTrain(unittest.TestCase):
     def test_mlp_str_labels(self):
         self.do_basic_run(['Porites', 'CCA', 'Sand'], 'MLP')
 
-    def test_mlp_hybrid_mode(self):
-
+    def test_mlp_annotation_threshold(self):
+        """
+        Test the default trainer's logic for automatically selecting MLP
+        parameters based on an annotation-count threshold.
+        """
         param_sets = [
             (11, 20, (100,), 1e-3),
+            # 100*1000 = 100000 total annotations; threshold is 50000
             (100, 1000, (200, 100), 1e-4),
         ]
 
@@ -212,11 +216,12 @@ class TestTrain(unittest.TestCase):
             clf_param = clf_calibrated.get_params()['estimator']
             self.assertEqual(
                 clf_param.hidden_layer_sizes, hls,
-                msg="Hidden layer sizes should correspond to label count")
+                msg="Hidden layer sizes should match the expected values"
+                    " for the annotation count")
             self.assertEqual(
                 clf_param.learning_rate_init, lr,
-                msg="Learning rate init value should correspond to label"
-                    " count")
+                msg="Learning rate init value should match the expected value"
+                    " for the annotation count")
 
     def test_custom_batch_size(self):
         feature_loc = DataLocation(storage_type='memory', key='')

--- a/spacer/tests/test_train_utils.py
+++ b/spacer/tests/test_train_utils.py
@@ -7,11 +7,11 @@ from spacer import config
 from spacer.data_classes import (
     DataLocation, ImageLabels, PointFeatures, ImageFeatures)
 from spacer.exceptions import RowColumnMismatchError, RowColumnMissingError
+from spacer.train_classifier import MiniBatchTrainer
 from spacer.train_utils import (
     calc_acc,
     evaluate_classifier,
     make_random_data,
-    train,
 )
 
 
@@ -46,81 +46,6 @@ class TestMakeRandom(unittest.TestCase):
             msg="Should have created features as expected")
 
 
-class TestTrain(unittest.TestCase):
-
-    def do_basic_run(self, class_list, clf_type):
-
-        n_traindata = 5
-        n_refdata = 1
-        points_per_image = 20
-        feature_dim = 5
-        num_epochs = 4
-        feature_loc = DataLocation(storage_type='memory', key='')
-
-        train_labels = make_random_data(
-            n_traindata, class_list, points_per_image,
-            feature_dim, feature_loc,
-        )
-        ref_labels = make_random_data(
-            n_refdata, class_list, points_per_image,
-            feature_dim, feature_loc,
-        )
-
-        clf_calibrated, ref_acc = train(
-            train_labels, ref_labels,
-            num_epochs, clf_type,
-        )
-
-        self.assertEqual(
-            len(ref_acc), num_epochs,
-            msg="Sanity check: expecting one ref_acc element per epoch")
-
-    def test_lr_int_labels(self):
-        self.do_basic_run([1, 2], 'LR')
-
-    def test_mlp_int_labels(self):
-        self.do_basic_run([1, 2], 'MLP')
-
-    def test_lr_str_labels(self):
-        self.do_basic_run(['Porites', 'CCA', 'Sand'], 'LR')
-
-    def test_mlp_str_labels(self):
-        self.do_basic_run(['Porites', 'CCA', 'Sand'], 'MLP')
-
-    def test_mlp_hybrid_mode(self):
-
-        param_sets = [
-            (11, 20, (100,), 1e-3),
-            (100, 1000, (200, 100), 1e-4),
-        ]
-
-        for (n_traindata, points_per_image, hls, lr) in param_sets:
-            feature_dim = 5
-            class_list = [1, 2]
-            num_epochs = 4
-            feature_loc = DataLocation(storage_type='memory', key='')
-
-            train_labels = make_random_data(
-                n_traindata, class_list, points_per_image,
-                feature_dim, feature_loc,
-            )
-            ref_labels = make_random_data(
-                1, class_list, points_per_image,
-                feature_dim, feature_loc,
-            )
-
-            clf_calibrated, ref_acc = train(
-                train_labels, ref_labels, num_epochs, 'MLP')
-            clf_param = clf_calibrated.get_params()['estimator']
-            self.assertEqual(
-                clf_param.hidden_layer_sizes, hls,
-                msg="Hidden layer sizes should correspond to label count")
-            self.assertEqual(
-                clf_param.learning_rate_init, lr,
-                msg="Learning rate init value should correspond to label"
-                    " count")
-
-
 class TestEvaluateClassifier(unittest.TestCase):
 
     def test_simple(self):
@@ -136,7 +61,7 @@ class TestEvaluateClassifier(unittest.TestCase):
             3, class_list, points_per_image, feature_dim, feature_loc)
 
         for clf_type in config.CLASSIFIER_TYPES:
-            clf, _ = train(train_data, ref_data, 1, clf_type)
+            clf, _ = MiniBatchTrainer()._train(train_data, ref_data, 1, clf_type)
 
             gts, ests, scores = evaluate_classifier(clf, val_data)
             # Sanity checks

--- a/spacer/tests/utils.py
+++ b/spacer/tests/utils.py
@@ -3,6 +3,7 @@
 from contextlib import contextmanager
 import tempfile
 import uuid
+from unittest import mock
 
 import numpy as np
 from PIL import Image
@@ -10,6 +11,20 @@ from PIL import Image
 from spacer import config
 from spacer.messages import DataLocation
 from spacer.storage import FileSystemStorage, S3Storage
+
+
+def spy_decorator(method_to_decorate):
+    """
+    A way to track calls to a class's instance method, across all instances
+    of the class. From:
+    https://stackoverflow.com/a/41599695
+    """
+    mock_obj = mock.MagicMock()
+    def wrapper(self, *args, **kwargs):
+        mock_obj(*args, **kwargs)
+        return method_to_decorate(self, *args, **kwargs)
+    wrapper.mock_obj = mock_obj
+    return wrapper
 
 
 def cn_beta_fixture_location(key):

--- a/spacer/train_classifier.py
+++ b/spacer/train_classifier.py
@@ -116,8 +116,14 @@ class MiniBatchTrainer(ClassifierTrainer):
         logger.debug(
             f"Mini-batch size: {self.batch_size} labels")
 
+        # The possible classes for this training.
+        # We derive this from the ref set, but it could just as well be from
+        # the train set, since preprocess_labels() already trimmed both sets
+        # down to the classes common to both.
         classes_list = list(ref_labels.classes_set)
 
+        # The entirety of the ref set is loaded here and then held in memory
+        # during the whole calibration process.
         with config.log_entry_and_exit("loading of reference data"):
             refx, refy = ref_labels.load_all_data()
 

--- a/spacer/train_classifier.py
+++ b/spacer/train_classifier.py
@@ -4,15 +4,21 @@ Defines train-classifier ABC; implementations; and factory.
 
 from __future__ import annotations
 import abc
+import inspect
 import time
 from importlib import import_module
+from logging import getLogger
 
 from sklearn.calibration import CalibratedClassifierCV
+from sklearn.linear_model import SGDClassifier
+from sklearn.neural_network import MLPClassifier
 
 from spacer import config
 from spacer.data_classes import ValResults
 from spacer.messages import TrainClassifierReturnMsg, TrainingTaskLabels
-from spacer.train_utils import train, evaluate_classifier, calc_acc
+from spacer.train_utils import evaluate_classifier, calc_acc
+
+logger = getLogger(__name__)
 
 _BUILTIN_TRAINERS: dict[str, str] = {
     'minibatch': 'spacer.train_classifier.MiniBatchTrainer',
@@ -67,8 +73,89 @@ class ClassifierTrainer(abc.ABC):  # pragma: no cover
 class MiniBatchTrainer(ClassifierTrainer):
     """
     This is the default trainer. It uses mini-batches of data
-    to train the classifier
+    to train the classifier.
     """
+
+    def __init__(
+        self,
+        batch_size: int = config.TRAINING_BATCH_LABEL_COUNT,
+        # MLP settings — None means auto-select based on label count
+        mlp_hidden_layer_sizes: tuple[int, ...] | None = None,
+        mlp_learning_rate_init: float | None = None,
+        # MLP auto-select threshold
+        mlp_large_data_threshold: int = 50000,
+        # SGD settings
+        sgd_loss: str = 'log_loss',
+        sgd_average: bool = True,
+        sgd_random_state: int = 0,
+    ):
+        self.batch_size = batch_size
+        self.mlp_hidden_layer_sizes = mlp_hidden_layer_sizes
+        self.mlp_learning_rate_init = mlp_learning_rate_init
+        self.mlp_large_data_threshold = mlp_large_data_threshold
+        self.sgd_loss = sgd_loss
+        self.sgd_average = sgd_average
+        self.sgd_random_state = sgd_random_state
+
+    def serialize(self) -> dict:
+        data = super().serialize()
+        sig = inspect.signature(self.__init__)
+        for name, param in sig.parameters.items():
+            value = getattr(self, name)
+            if value != param.default:
+                data[name] = value
+        return data
+
+    def _train(self, train_labels, ref_labels, nbr_epochs, clf_type):
+        logger.debug(
+            f"Data sets:"
+            f" Train = {len(train_labels)} images,"
+            f" {train_labels.label_count} labels;"
+            f" Ref = {len(ref_labels)} images,"
+            f" {ref_labels.label_count} labels")
+        logger.debug(
+            f"Mini-batch size: {self.batch_size} labels")
+
+        classes_list = list(ref_labels.classes_set)
+
+        with config.log_entry_and_exit("loading of reference data"):
+            refx, refy = ref_labels.load_all_data()
+
+        with config.log_entry_and_exit("training using " + clf_type):
+            if clf_type == 'MLP':
+                if self.mlp_hidden_layer_sizes is not None:
+                    hls = self.mlp_hidden_layer_sizes
+                    lr = self.mlp_learning_rate_init or 1e-3
+                elif train_labels.label_count >= self.mlp_large_data_threshold:
+                    hls, lr = (200, 100), 1e-4
+                else:
+                    hls, lr = (100,), 1e-3
+                clf = MLPClassifier(
+                    hidden_layer_sizes=hls, learning_rate_init=lr)
+            else:
+                clf = SGDClassifier(
+                    loss=self.sgd_loss,
+                    average=self.sgd_average,
+                    random_state=self.sgd_random_state,
+                )
+
+            ref_acc = []
+
+            for epoch in range(nbr_epochs):
+                for x, y in train_labels.load_data_in_batches(
+                    batch_size=self.batch_size,
+                    random_seed=epoch,
+                ):
+                    clf.partial_fit(x, y, classes=classes_list)
+
+                ref_acc.append(calc_acc(refy, clf.predict(refx)))
+                logger.debug(f"Epoch {epoch}, acc: {ref_acc[-1]}")
+
+        with config.log_entry_and_exit("calibration"):
+            clf_calibrated = CalibratedClassifierCV(clf, cv="prefit")
+            clf_calibrated.fit(refx, refy)
+
+        return clf_calibrated, ref_acc
 
     def __call__(self,
                  labels,
@@ -79,7 +166,7 @@ class MiniBatchTrainer(ClassifierTrainer):
         assert clf_type in config.CLASSIFIER_TYPES
         # Train.
         t0 = time.time()
-        clf, ref_accs = train(
+        clf, ref_accs = self._train(
             labels['train'], labels['ref'], nbr_epochs, clf_type)
         classes = clf.classes_.tolist()
 

--- a/spacer/train_utils.py
+++ b/spacer/train_utils.py
@@ -5,71 +5,12 @@ Utility methods for training classifiers.
 from __future__ import annotations
 import random
 import string
-from logging import getLogger
 
 import numpy as np
 from sklearn.calibration import CalibratedClassifierCV
-from sklearn.linear_model import SGDClassifier
-from sklearn.neural_network import MLPClassifier
 
-from spacer import config
 from spacer.data_classes import (
     DataLocation, ImageLabels, ImageFeatures, LabelId)
-
-logger = getLogger(__name__)
-
-
-def train(train_labels: ImageLabels,
-          ref_labels: ImageLabels,
-          nbr_epochs: int,
-          clf_type: str) -> tuple[CalibratedClassifierCV, list[float]]:
-
-    logger.debug(
-        f"Data sets:"
-        f" Train = {len(train_labels)} images,"
-        f" {train_labels.label_count} labels;"
-        f" Ref = {len(ref_labels)} images,"
-        f" {ref_labels.label_count} labels")
-    logger.debug(
-        f"Mini-batch size: {config.TRAINING_BATCH_LABEL_COUNT} labels")
-
-    # train_labels and ref_labels should already be trimmed down to the
-    # classes common to both, so the classes_set from either one should be the
-    # set used for training.
-    classes_list = list(ref_labels.classes_set)
-
-    # Load reference data (must hold in memory for the calibration)
-    with config.log_entry_and_exit("loading of reference data"):
-        refx, refy = ref_labels.load_all_data()
-
-    # Initialize classifier and ref set accuracy list
-    with config.log_entry_and_exit("training using " + clf_type):
-        if clf_type == 'MLP':
-            if train_labels.label_count >= 50000:
-                hls, lr = (200, 100), 1e-4
-            else:
-                hls, lr = (100,), 1e-3
-            clf = MLPClassifier(hidden_layer_sizes=hls, learning_rate_init=lr)
-        else:
-            clf = SGDClassifier(loss='log_loss', average=True, random_state=0)
-
-        ref_acc = []
-
-        for epoch in range(nbr_epochs):
-            for x, y in train_labels.load_data_in_batches(
-                batch_size=config.TRAINING_BATCH_LABEL_COUNT,
-                random_seed=epoch,
-            ):
-                clf.partial_fit(x, y, classes=classes_list)
-
-            ref_acc.append(calc_acc(refy, clf.predict(refx)))
-            logger.debug(f"Epoch {epoch}, acc: {ref_acc[-1]}")
-
-    with config.log_entry_and_exit("calibration"):
-        clf_calibrated = CalibratedClassifierCV(clf, cv="prefit")
-        clf_calibrated.fit(refx, refy)
-
-    return clf_calibrated, ref_acc
 
 
 def evaluate_classifier(clf: CalibratedClassifierCV,


### PR DESCRIPTION
## Goal
To allow more control over the training loop in the mermaid classifier (see for example https://github.com/data-mermaid/mermaid-classifier/pull/18)

To accomplish this, we are allowing inheritance of the ClassifierTrainer here. This in turn allows defining custom training logic within an inherited trainer class. 

See this discussion for more background: https://github.com/data-mermaid/mermaid-classifier/issues/17

## These changes include
- make it possible to inherit from the ClassifierTrainer, and use that inherited trainer instead of the default MiniBatchTrainer
- If you do not specify a custom trainer, behaviour remains unchanged, and the default MiniBatchTrainer is still used.